### PR TITLE
BAU: refactor cucumber step definitions to support additional scenarios

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
@@ -15,7 +15,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
 
@@ -30,8 +29,7 @@ public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
     }
 
     @Given("the services are running")
-    public void theServicesAreRunning() {
-    }
+    public void theServicesAreRunning() {}
 
     @When("the user visits the stub relying party")
     public void theExistingUserVisitsTheStubRelyingParty() {
@@ -49,7 +47,8 @@ public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
         waitForPageLoad("Sign in to or create your GOV.UK Account");
         assertEquals("/enter-email", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
-        assertEquals("Sign in to or create your GOV.UK Account - GOV.UK Account", driver.getTitle());
+        assertEquals(
+                "Sign in to or create your GOV.UK Account - GOV.UK Account", driver.getTitle());
     }
 
     @And("the user clicks link {string}")
@@ -68,6 +67,7 @@ public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
     }
 
     private void waitForPageLoad(String titleContains) {
-        new WebDriverWait(driver, DEFAULT_PAGE_LOAD_WAIT_TIME).until(ExpectedConditions.titleContains(titleContains));
+        new WebDriverWait(driver, DEFAULT_PAGE_LOAD_WAIT_TIME)
+                .until(ExpectedConditions.titleContains(titleContains));
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
@@ -1,0 +1,73 @@
+package uk.gov.di.test.acceptance;
+
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
+
+    @Before
+    public void setupWebdriver() throws MalformedURLException {
+        super.setupWebdriver();
+    }
+
+    @After
+    public void closeWebdriver() {
+        super.closeWebdriver();
+    }
+
+    @Given("the services are running")
+    public void theServicesAreRunning() {
+    }
+
+    @When("the user visits the stub relying party")
+    public void theExistingUserVisitsTheStubRelyingParty() {
+        driver.get(RP_URL.toString());
+    }
+
+    @And("the user clicks {string}")
+    public void theExistingUserClicks(String buttonName) {
+        WebElement button = driver.findElement(By.id(buttonName));
+        button.click();
+    }
+
+    @Then("the user is taken to the Identity Provider Login Page")
+    public void theExistingUserIsTakenToTheIdentityProviderLoginPage() {
+        waitForPageLoad("Sign in to or create your GOV.UK Account");
+        assertEquals("/enter-email", URI.create(driver.getCurrentUrl()).getPath());
+        assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
+        assertEquals("Sign in to or create your GOV.UK Account - GOV.UK Account", driver.getTitle());
+    }
+
+    @And("the user clicks link {string}")
+    public void theUserClicksLink(String linkText) {
+        driver.findElement(By.partialLinkText(linkText)).click();
+    }
+
+    @Then("the user is taken to the page with title containing {string}")
+    public void theUserIsTakenToThePageWithTitleContaining(String title) {
+        waitForPageLoad(title);
+    }
+
+    @And("the user navigates back")
+    public void theUserNavigatesBack() {
+        driver.navigate().back();
+    }
+
+    private void waitForPageLoad(String titleContains) {
+        new WebDriverWait(driver, DEFAULT_PAGE_LOAD_WAIT_TIME).until(ExpectedConditions.titleContains(titleContains));
+    }
+}

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -1,0 +1,120 @@
+package uk.gov.di.test.acceptance;
+
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LoginStepDefinitions extends SignInStepDefinitions {
+
+    private String emailAddress;
+    private String password;
+
+    @Before
+    public void setupWebdriver() throws MalformedURLException {
+        super.setupWebdriver();
+    }
+
+    @After
+    public void closeWebdriver() {
+        super.closeWebdriver();
+    }
+
+    @Given("the login services are running")
+    public void theServicesAreRunning() {
+    }
+
+    @And("the existing user has valid credentials")
+    public void theExistingUserHasValidCredentials() {
+        emailAddress = "joe.bloggs@digital.cabinet-office.gov.uk";
+        password = "password";
+    }
+
+    @And("the existing user has invalid credentials")
+    public void theExistingUserHasInvalidCredentials() {
+        emailAddress = "joe.bloggs@digital.cabinet-office.gov.uk";
+        password = "wrong-password";
+    }
+
+
+    @When("the existing user visits the stub relying party")
+    public void theExistingUserVisitsTheStubRelyingParty() {
+        driver.get(RP_URL.toString());
+    }
+
+    @And("the existing user clicks {string}")
+    public void theExistingUserClicks(String buttonName) {
+        WebElement button = driver.findElement(By.id(buttonName));
+        button.click();
+    }
+
+    @Then("the existing user is taken to the Identity Provider Login Page")
+    public void theExistingUserIsTakenToTheIdentityProviderLoginPage() {
+        waitForPageLoad("Sign in to or create your GOV.UK Account");
+        assertEquals("/enter-email", URI.create(driver.getCurrentUrl()).getPath());
+        assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
+        assertEquals("Sign in to or create your GOV.UK Account - GOV.UK Account", driver.getTitle());
+    }
+
+    @When("the existing user enters their email address")
+    public void theExistingUserEntersEmailAddress() {
+        WebElement emailAddressField = driver.findElement(By.id("email"));
+        emailAddressField.sendKeys(emailAddress);
+        WebElement continueButton = driver.findElement(By.xpath("//button[text()[normalize-space() = 'Continue']]"));
+        continueButton.click();
+    }
+
+    @Then("the existing user is prompted for password")
+    public void theExistingUserIsPromptedForPassword() {
+        assertEquals("/login", URI.create(driver.getCurrentUrl()).getPath());
+        assertEquals("Sign-in to GOV.UK - Password", driver.getTitle());
+    }
+
+    @When("the existing user enters their password")
+    public void theExistingUserEntersTheirPassword() {
+        WebElement passwordField = driver.findElement(By.id("password"));
+        passwordField.sendKeys(password);
+    }
+
+
+
+    @Then("the existing user is taken to the Service User Info page")
+    public void theExistingUserIsTakenToTheServiceUserInfoPage() {
+        assertEquals("/oidc/callback", URI.create(driver.getCurrentUrl()).getPath());
+        assertEquals(RP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
+        assertEquals(RP_URL.getPort(), URI.create(driver.getCurrentUrl()).getPort());
+        assertEquals("Example - GOV.UK - User Info", driver.getTitle());
+        WebElement emailDescriptionDetails = driver.findElement(By.id("user-info-email"));
+        assertEquals(emailAddress, emailDescriptionDetails.getText().trim());
+    }
+
+    @Then("the existing user is shown an error message")
+    public void theExistingUserIsShownAnErrorMessageOnTheEnterEmailPage() {
+        WebElement emailDescriptionDetails = driver.findElement(By.id("error-summary-title"));
+        assertTrue(emailDescriptionDetails.isDisplayed());
+    }
+
+    private void waitForPageLoad(String titleContains) {
+        new WebDriverWait(driver, DEFAULT_PAGE_LOAD_WAIT_TIME).until(ExpectedConditions.titleContains(titleContains));
+    }
+}

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -6,21 +6,13 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,8 +33,7 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
     }
 
     @Given("the login services are running")
-    public void theServicesAreRunning() {
-    }
+    public void theServicesAreRunning() {}
 
     @And("the existing user has valid credentials")
     public void theExistingUserHasValidCredentials() {
@@ -55,7 +46,6 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
         emailAddress = "joe.bloggs@digital.cabinet-office.gov.uk";
         password = "wrong-password";
     }
-
 
     @When("the existing user visits the stub relying party")
     public void theExistingUserVisitsTheStubRelyingParty() {
@@ -73,14 +63,16 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
         waitForPageLoad("Sign in to or create your GOV.UK Account");
         assertEquals("/enter-email", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
-        assertEquals("Sign in to or create your GOV.UK Account - GOV.UK Account", driver.getTitle());
+        assertEquals(
+                "Sign in to or create your GOV.UK Account - GOV.UK Account", driver.getTitle());
     }
 
     @When("the existing user enters their email address")
     public void theExistingUserEntersEmailAddress() {
         WebElement emailAddressField = driver.findElement(By.id("email"));
         emailAddressField.sendKeys(emailAddress);
-        WebElement continueButton = driver.findElement(By.xpath("//button[text()[normalize-space() = 'Continue']]"));
+        WebElement continueButton =
+                driver.findElement(By.xpath("//button[text()[normalize-space() = 'Continue']]"));
         continueButton.click();
     }
 
@@ -95,8 +87,6 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
         WebElement passwordField = driver.findElement(By.id("password"));
         passwordField.sendKeys(password);
     }
-
-
 
     @Then("the existing user is taken to the Service User Info page")
     public void theExistingUserIsTakenToTheServiceUserInfoPage() {
@@ -115,6 +105,7 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
     }
 
     private void waitForPageLoad(String titleContains) {
-        new WebDriverWait(driver, DEFAULT_PAGE_LOAD_WAIT_TIME).until(ExpectedConditions.titleContains(titleContains));
+        new WebDriverWait(driver, DEFAULT_PAGE_LOAD_WAIT_TIME)
+                .until(ExpectedConditions.titleContains(titleContains));
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -7,73 +7,38 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class StepDefinitions {
-
-    private static final String SELENIUM_URL = System.getenv().get("SELENIUM_URL");
-    private static final URI IDP_URL = URI.create(
-            System.getenv().getOrDefault("IDP_URL", "http://localhost:8080/")
-    );
-    private static final URI RP_URL = URI.create(
-            System.getenv().getOrDefault("RP_URL","http://localhost:8081/")
-    );
-
-    private static final int DEFAULT_PAGE_LOAD_WAIT_TIME = 20;
-
-    private WebDriver driver;
+public class RegistrationStepDefinitions extends SignInStepDefinitions {
 
     private String emailAddress;
     private String password;
 
     @Before
     public void setupWebdriver() throws MalformedURLException {
-        FirefoxOptions firefoxOptions = new FirefoxOptions();
-        firefoxOptions.setHeadless(true);
-        if (SELENIUM_URL == null) {
-            driver = new FirefoxDriver(firefoxOptions);
-        } else {
-            driver = new RemoteWebDriver(new URL(SELENIUM_URL), firefoxOptions);
-        }
+        super.setupWebdriver();
     }
 
     @After
     public void closeWebdriver() {
-        driver.quit();
+        super.closeWebdriver();
     }
 
-    @Given("the services are running")
+    @Given("the registration services are running")
     public void theServicesAreRunning() {
     }
 
-    @And("the user has valid credentials")
-    public void theUserHasValidCredentials() {
-        emailAddress = "joe.bloggs@digital.cabinet-office.gov.uk";
-        password = "password";
-    }
-
-    @And("the user has invalid credentials")
-    public void theUserHasInvalidCredentials() {
-        emailAddress = "joe.bloggs@digital.cabinet-office.gov.uk";
-        password = "wrong-password";
-    }
-
-    @And("the user has an invalid email format")
-    public void theUserHasInvalidEmail() {
+    @And("the new user has an invalid email format")
+    public void theNewUserHasInvalidEmail() {
         emailAddress = "joe.bloggs";
         password = "password";
     }
@@ -91,87 +56,75 @@ public class StepDefinitions {
         password = "passw0rd1";
     }
 
-    @When("the user visit the stub relying party")
-    public void theUserVisitTheStubRelyingParty() {
+    @When("the new user visits the stub relying party")
+    public void theNewUserVisitsTheStubRelyingParty() {
         driver.get(RP_URL.toString());
     }
 
-    @And("the user clicks {string}")
-    public void theUserClick(String buttonName) {
+    @And("the new user clicks {string}")
+    public void theNewUserClicks(String buttonName) {
         WebElement button = driver.findElement(By.id(buttonName));
         button.click();
     }
 
-    @Then("the user is taken to the Identity Provider Login Page")
-    public void theUserIsTakenToTheIdentityProviderLoginPage() {
+    @Then("the new user is taken to the Identity Provider Login Page")
+    public void theNewUserIsTakenToTheIdentityProviderLoginPage() {
         waitForPageLoad("Sign in to or create your GOV.UK Account");
         assertEquals("/enter-email", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
         assertEquals("Sign in to or create your GOV.UK Account - GOV.UK Account", driver.getTitle());
     }
 
-    @When("the user enters their email address")
-    public void theUserEntersEmailAddress() {
+    @When("the new user enters their email address")
+    public void theNewUserEntersEmailAddress() {
         WebElement emailAddressField = driver.findElement(By.id("email"));
         emailAddressField.sendKeys(emailAddress);
         WebElement continueButton = driver.findElement(By.xpath("//button[text()[normalize-space() = 'Continue']]"));
         continueButton.click();
     }
 
-    @Then("the user is asked to check their email")
-    public void theUserIsAskedToCheckTheirEmail() {
+    @Then("the new user is asked to check their email")
+    public void theNewUserIsAskedToCheckTheirEmail() {
         waitForPageLoad("Check your email");
         assertEquals("/check-your-email", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals("Check your email - GOV.UK Account", driver.getTitle());
     }
 
-    @Then("the user is prompted for password")
-    public void theUserIsPromptedForPassword() {
-        assertEquals("/login", URI.create(driver.getCurrentUrl()).getPath());
-        assertEquals("Sign-in to GOV.UK - Password", driver.getTitle());
-    }
-
-    @Then("the user is asked to create a password")
-    public void theUserIsAskedToCreateAPassword() {
+    @Then("the new user is asked to create a password")
+    public void theNewUserIsAskedToCreateAPassword() {
         assertEquals("/registration", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals("Create your GOV.UK account password", driver.getTitle());
     }
 
-    @Then("the user is asked again to create a password")
-    public void theUserIsAskedAgainToCreateAPassword() {
+    @Then("the new user is asked again to create a password")
+    public void theNewUserIsAskedAgainToCreateAPassword() {
         assertEquals("/registration/validate", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals("Create your GOV.UK account password", driver.getTitle());
     }
 
-    @When("the user enters their password")
-    public void theUserEntersTheirPassword() {
-        WebElement passwordField = driver.findElement(By.id("password"));
-        passwordField.sendKeys(password);
-    }
-
-    @When("the user registers their password")
-    public void theUserEntersANewPassword() {
+    @When("the new user registers their password")
+    public void theNewUserEntersANewPassword() {
         WebElement passwordField = driver.findElement(By.id("password"));
         passwordField.sendKeys(password);
         WebElement passwordConfirmField = driver.findElement(By.id("password-confirm"));
         passwordConfirmField.sendKeys(password);
     }
 
-    @Then("the user is taken to the Success page")
-    public void theUserIsTakenToTheSuccessPage() {
+    @Then("the new user is taken to the Success page")
+    public void theNewUserIsTakenToTheSuccessPage() {
         assertEquals("/login/validate", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals("Sign-in to GOV.UK - Success", driver.getTitle());
     }
 
-    @Then("the user is taken to the successfully registered page")
-    public void theUserIsTakenToTheSuccessfullyRegisteredPage() {
+    @Then("the new user is taken to the successfully registered page")
+    public void theNewUserIsTakenToTheSuccessfullyRegisteredPage() {
         assertEquals("/registration/validate", URI.create(driver.getCurrentUrl()).getPath());
         WebElement element = driver.findElement(By.id("successfully-created-account"));
         assertEquals("You have successfully created your GOV.UK Account", element.getText().trim());
     }
 
-    @Then("the user is taken to the Service User Info page")
-    public void theUserIsTakenToTheServiceUserInfoPage() {
+    @Then("the new user is taken to the Service User Info page")
+    public void theNewUserIsTakenToTheServiceUserInfoPage() {
         assertEquals("/oidc/callback", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(RP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
         assertEquals(RP_URL.getPort(), URI.create(driver.getCurrentUrl()).getPort());
@@ -180,8 +133,8 @@ public class StepDefinitions {
         assertEquals(emailAddress, emailDescriptionDetails.getText().trim());
     }
 
-    @Then("the user is shown an error message")
-    public void theUserIsShownAnErrorMessageOnTheEnterEmailPage() {
+    @Then("the new user is shown an error message")
+    public void theNewUserIsShownAnErrorMessageOnTheEnterEmailPage() {
         WebElement emailDescriptionDetails = driver.findElement(By.id("error-summary-title"));
         assertTrue(emailDescriptionDetails.isDisplayed());
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -34,8 +34,7 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     }
 
     @Given("the registration services are running")
-    public void theServicesAreRunning() {
-    }
+    public void theServicesAreRunning() {}
 
     @And("the new user has an invalid email format")
     public void theNewUserHasInvalidEmail() {
@@ -52,7 +51,7 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     @And("a new user has valid credentials")
     public void theNewUserHasValidCredential() {
         String randomString = UUID.randomUUID().toString();
-        emailAddress = "susan.bloggs+"+randomString+"@digital.cabinet-office.gov.uk";
+        emailAddress = "susan.bloggs+" + randomString + "@digital.cabinet-office.gov.uk";
         password = "passw0rd1";
     }
 
@@ -72,14 +71,16 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         waitForPageLoad("Sign in to or create your GOV.UK Account");
         assertEquals("/enter-email", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
-        assertEquals("Sign in to or create your GOV.UK Account - GOV.UK Account", driver.getTitle());
+        assertEquals(
+                "Sign in to or create your GOV.UK Account - GOV.UK Account", driver.getTitle());
     }
 
     @When("the new user enters their email address")
     public void theNewUserEntersEmailAddress() {
         WebElement emailAddressField = driver.findElement(By.id("email"));
         emailAddressField.sendKeys(emailAddress);
-        WebElement continueButton = driver.findElement(By.xpath("//button[text()[normalize-space() = 'Continue']]"));
+        WebElement continueButton =
+                driver.findElement(By.xpath("//button[text()[normalize-space() = 'Continue']]"));
         continueButton.click();
     }
 
@@ -140,6 +141,7 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     }
 
     private void waitForPageLoad(String titleContains) {
-        new WebDriverWait(driver, DEFAULT_PAGE_LOAD_WAIT_TIME).until(ExpectedConditions.titleContains(titleContains));
+        new WebDriverWait(driver, DEFAULT_PAGE_LOAD_WAIT_TIME)
+                .until(ExpectedConditions.titleContains(titleContains));
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RunCucumberTest.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RunCucumberTest.java
@@ -6,6 +6,4 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(plugin = {"pretty"})
-public class RunCucumberTest {
-
-}
+public class RunCucumberTest {}

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
@@ -1,7 +1,5 @@
 package uk.gov.di.test.acceptance;
 
-import io.cucumber.java.Before;
-import io.cucumber.java.en.Given;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
@@ -13,12 +11,10 @@ import java.net.URL;
 
 public class SignInStepDefinitions {
     protected static final String SELENIUM_URL = System.getenv().get("SELENIUM_URL");
-    protected static final URI IDP_URL = URI.create(
-            System.getenv().getOrDefault("IDP_URL", "http://localhost:8080/")
-    );
-    protected static final URI RP_URL = URI.create(
-            System.getenv().getOrDefault("RP_URL", "http://localhost:8081/")
-    );
+    protected static final URI IDP_URL =
+            URI.create(System.getenv().getOrDefault("IDP_URL", "http://localhost:8080/"));
+    protected static final URI RP_URL =
+            URI.create(System.getenv().getOrDefault("RP_URL", "http://localhost:8081/"));
     protected static final int DEFAULT_PAGE_LOAD_WAIT_TIME = 20;
     protected WebDriver driver;
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
@@ -1,0 +1,38 @@
+package uk.gov.di.test.acceptance;
+
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+public class SignInStepDefinitions {
+    protected static final String SELENIUM_URL = System.getenv().get("SELENIUM_URL");
+    protected static final URI IDP_URL = URI.create(
+            System.getenv().getOrDefault("IDP_URL", "http://localhost:8080/")
+    );
+    protected static final URI RP_URL = URI.create(
+            System.getenv().getOrDefault("RP_URL", "http://localhost:8081/")
+    );
+    protected static final int DEFAULT_PAGE_LOAD_WAIT_TIME = 20;
+    protected WebDriver driver;
+
+    protected void setupWebdriver() throws MalformedURLException {
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.setHeadless(true);
+        if (SELENIUM_URL == null) {
+            driver = new FirefoxDriver(firefoxOptions);
+        } else {
+            driver = new RemoteWebDriver(new URL(SELENIUM_URL), firefoxOptions);
+        }
+    }
+
+    protected void closeWebdriver() {
+        driver.quit();
+    }
+}

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/legal_and_policy_pages.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/legal_and_policy_pages.feature
@@ -1,0 +1,14 @@
+Feature: Legal and policy pages
+  User clicks on the legal and policy pages
+
+  Scenario: User views legal and policy pages
+    Given the services are running
+    When the user visits the stub relying party
+    And the user clicks "govuk-signin-button"
+    Then the user is taken to the Identity Provider Login Page
+    When the user clicks link "Accessibility statement"
+    Then the user is taken to the page with title containing "Accessibility statement"
+    When the user navigates back
+    Then the user is taken to the Identity Provider Login Page
+    When the user clicks link "Cookies"
+    Then the user is taken to the page with title containing "Cookies"

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/login_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/login_journey.feature
@@ -1,12 +1,12 @@
 Feature: Login Journey
-  User walks through a login journey
+  Existing user walks through a login journey
 
-  Scenario: User is correctly prompted to login
-    Given the services are running
-    And the user has valid credentials
-    When the user visit the stub relying party
-    And the user clicks "govuk-signin-button"
-    Then the user is taken to the Identity Provider Login Page
+  Scenario: Existing user is correctly prompted to login
+    Given the login services are running
+    And the existing user has valid credentials
+    When the existing user visits the stub relying party
+    And the existing user clicks "govuk-signin-button"
+    Then the existing user is taken to the Identity Provider Login Page
 #    When the user enters their email address
 #    Then the user is prompted for password
 #    When the user enters their password

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/registration_journey.feature
@@ -1,21 +1,21 @@
 Feature: Registration Journey
-  User walks through a registration journey
+  New user walks through a registration journey
 
   Scenario: User successfully registers
-    Given the services are running
+    Given the registration services are running
     And a new user has valid credentials
-    When the user visit the stub relying party
-    And the user clicks "govuk-signin-button"
-    Then the user is taken to the Identity Provider Login Page
-    When the user enters their email address
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user enters their email address
 #    Then the user is asked to check their email
 
   Scenario: User registers with an insecure password
-    Given the services are running
+    Given the registration services are running
     And a new user has an insecure password
-    When the user visit the stub relying party
-    And the user clicks "govuk-signin-button"
-    Then the user is taken to the Identity Provider Login Page
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
 #    When the user enters their email address
 #    Then the user is asked to create a password
 #    When the user registers their password
@@ -24,10 +24,10 @@ Feature: Registration Journey
 #    And the user is asked again to create a password
 
   Scenario: User registers with an invalid email
-    Given the services are running
-    And the user has an invalid email format
-    When the user visit the stub relying party
-    And the user clicks "govuk-signin-button"
-    Then the user is taken to the Identity Provider Login Page
-    When the user enters their email address
-    Then the user is shown an error message
+    Given the registration services are running
+    And the new user has an invalid email format
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user enters their email address
+    Then the new user is shown an error message

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,18 @@
 plugins {
     id 'java'
+    id "com.diffplug.spotless" version "5.14.2"
 }
 
 group 'uk.gov.di'
 version '1.0-SNAPSHOT'
+
+spotless {
+    java {
+        target '**/*.java'
+        googleJavaFormat('1.11.0').aosp()
+        importOrder '', 'javax', 'java', '\\#'
+    }
+}
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,12 @@
+
+# `google-java-format` used via `spotless` requires access to classes not normally exported by the
+# JDK in Java 16. We therefore need to export them here.
+# See:
+# https://github.com/diffplug/spotless/issues/834#issuecomment-819118761
+# https://github.com/google/google-java-format/releases/tag/v1.10.0
+
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -46,7 +46,7 @@ start_docker_services selenium
 sleep 5
 
 export SELENIUM_URL="http://localhost:4444/wd/hub"
-export IDP_URL="https://di-authentication-frontend.london.cloudapps.digital/"
+export IDP_URL="https://front.build.auth.ida.digital.cabinet-office.gov.uk/"
 export RP_URL="https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
 
 ./gradlew cucumber


### PR DESCRIPTION
## What?

Refactor cucumber step definitions to support additional scenarios.
Reword steps for new and existing user scenarios.
Add scenarios to check accessibility and cookies pages links.
Add spotless + reformat.

## Why?

All the step definitions were in one file which is not scalable.