### PR TITLE
BAU: Add Docker Hub username to manifest

### DIFF
--- a/nginx/manifest.yml
+++ b/nginx/manifest.yml
@@ -18,3 +18,4 @@ applications:
   - name: selenium-build
     docker:
       image: selenium/standalone-firefox:latest
+      username: ((docker-hub-username))


### PR DESCRIPTION
## What?

- Add Docker Hub username to manifest
- Password is provided via `CF_DOCKER_PASSWORD` environment inject in pipeline.

## Why?

Required to avoid Docker Hub rate limiting. Previous PR was raised to provide username on command in pipeline, but that doesn't work when using a manifest.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/26
https://github.com/alphagov/di-infrastructure/pull/24