### PR TITLE
BAU: Fix expected page titles in acceptance tests

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
@@ -42,10 +42,10 @@ public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
 
     @Then("the user is taken to the Identity Provider Login Page")
     public void theExistingUserIsTakenToTheIdentityProviderLoginPage() {
-        waitForPageLoad("Sign in or create a GOV.UK account");
+        waitForPageLoad("Create a GOV.UK account or sign in");
         assertEquals("/sign-in-or-create", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
-        assertEquals("Sign in or create a GOV.UK account - GOV.UK Account", driver.getTitle());
+        assertEquals("Create a GOV.UK account or sign in - GOV.UK account", driver.getTitle());
     }
 
     @And("the user clicks link {string}")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -58,10 +58,10 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
 
     @Then("the existing user is taken to the Identity Provider Login Page")
     public void theExistingUserIsTakenToTheIdentityProviderLoginPage() {
-        waitForPageLoad("Sign in or create a GOV.UK account");
+        waitForPageLoad("Create a GOV.UK account or sign in");
         assertEquals("/sign-in-or-create", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
-        assertEquals("Sign in or create a GOV.UK account - GOV.UK Account", driver.getTitle());
+        assertEquals("Create a GOV.UK account or sign in - GOV.UK account", driver.getTitle());
     }
 
     @When("the existing user enters their email address")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -66,10 +66,10 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
 
     @Then("the new user is taken to the Identity Provider Login Page")
     public void theNewUserIsTakenToTheIdentityProviderLoginPage() {
-        waitForPageLoad("Sign in or create a GOV.UK account");
+        waitForPageLoad("Create a GOV.UK account or sign in");
         assertEquals("/sign-in-or-create", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
-        assertEquals("Sign in or create a GOV.UK account - GOV.UK Account", driver.getTitle());
+        assertEquals("Create a GOV.UK account or sign in - GOV.UK account", driver.getTitle());
     }
 
     @When("the new user enters their email address")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/accountmanagement/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/accountmanagement/AccountManagementStepDefinitions.java
@@ -44,9 +44,9 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
 
     @Then("the existing account management user is taken to the Identity Provider Login Page")
     public void theExistingAccountManagementUserIsTakenToTheIdentityProviderLoginPage() {
-        waitForPageLoad("Sign in or create a GOV.UK account");
+        waitForPageLoad("Create a GOV.UK account or sign in");
         assertEquals("/sign-in-or-create", URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
-        assertEquals("Sign in or create a GOV.UK account - GOV.UK Account", driver.getTitle());
+        assertEquals("Create a GOV.UK account or sign in - GOV.UK account", driver.getTitle());
     }
 }


### PR DESCRIPTION
## What?

- Change expected page title to "Create a GOV.UK account or sign in - GOV.UK account"

## Why?

The content has changed and the page titles have changed.
