### PR TITLE
BAU - Increase disk quota

### DIFF
--- a/nginx/manifest.yml
+++ b/nginx/manifest.yml
@@ -16,6 +16,7 @@ applications:
       ALLOWED_IPS: ((allowed-ips))
 
   - name: selenium-build
+    disk_quota: 2G
     docker:
       image: selenium/standalone-firefox:latest
       username: ((docker-hub-username))


### PR DESCRIPTION

## What?

- Currently seeing the following error `writing blob to tempfile: uncompressed layer size exceeds quota` when trying to deploy. I believe this is caused because the docker image is larger than the disk size. Increase the disk size so it can handle the docker image


## Why?

- So selenium can deploy without error 