### PR TITLE
BAU: pin selenium docker image

### DIFF
--- a/nginx/manifest.yml
+++ b/nginx/manifest.yml
@@ -18,5 +18,5 @@ applications:
   - name: selenium-build
     disk_quota: 2G
     docker:
-      image: selenium/standalone-firefox:latest
+      image: selenium/standalone-firefox@sha256:310bc1151faf62015fae3d48efccc2c7fa655cac167db864c4e9e5fa6f068630
       username: ((docker-hub-username))


### PR DESCRIPTION
## What?

Pin selenium docker image.

## Why?

Image tag was set to 'latest' and the latest version is failing.

Set back to previous.