### PR TITLE
BAU: fix update password by maintaining the session between scenarios

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -1,24 +1,22 @@
 package uk.gov.di.test.acceptance;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.gov.di.test.acceptance.AccountJourneyPages.CHANGE_PASSWORD;
-import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_CHANGE_PASSWORD;
-import static uk.gov.di.test.acceptance.AccountJourneyPages.MANAGE_YOUR_ACCOUNT;
-import static uk.gov.di.test.acceptance.AccountJourneyPages.PASSWORD_UPDATED_CONFIRMATION;
-
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.util.UUID;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-
-import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.test.acceptance.AccountJourneyPages.CHANGE_PASSWORD;
+import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_CHANGE_PASSWORD;
+import static uk.gov.di.test.acceptance.AccountJourneyPages.MANAGE_YOUR_ACCOUNT;
+import static uk.gov.di.test.acceptance.AccountJourneyPages.PASSWORD_UPDATED_CONFIRMATION;
 
 public class AccountManagementStepDefinitions extends SignInStepDefinitions {
 
@@ -29,11 +27,6 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
     @Before
     public void setupWebdriver() throws MalformedURLException {
         super.setupWebdriver();
-    }
-
-    @After
-    public void closeWebdriver() {
-        super.closeWebdriver();
     }
 
     @Given("the account management services are running")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
@@ -1,18 +1,17 @@
 package uk.gov.di.test.acceptance;
 
-import static org.junit.Assert.assertEquals;
-
-import java.net.MalformedURLException;
-import java.net.URI;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-
 import io.cucumber.java.Before;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
 
 public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
 
@@ -21,7 +20,6 @@ public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
         super.setupWebdriver();
     }
 
-    
     @Given("the services are running")
     public void theServicesAreRunning() {}
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -1,23 +1,22 @@
 package uk.gov.di.test.acceptance;
 
+import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PASSWORD;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.SIGN_IN_OR_CREATE;
-
-import java.net.MalformedURLException;
-import java.net.URI;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-
-import io.cucumber.java.Before;
-import io.cucumber.java.en.And;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
 
 public class LoginStepDefinitions extends SignInStepDefinitions {
 


### PR DESCRIPTION
## What?

Fix update password by maintaining the session between scenarios ( closeWebdriver() call )

Some additional spotless formatting.

## Why?

Update password test failing as the session is cleared before the test starts.

## Related

#31 