### PR TITLE
BAU: add registration validation scenarios

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,7 @@
 # Update these environment variables to test the scenarios locally and rename to .env
 SELENIUM_URL="http://localhost:4444/wd/hub"
+SELENIUM_BROWSER=firefox
+SELENIUM_LOCAL=false
 IDP_URL="https://front.build.auth.ida.digital.cabinet-office.gov.uk/"
 RP_URL="https://di-auth-stub-relying-party-build-s2.london.cloudapps.digital/"
 AM_URL="https://account-management.build.auth.ida.digital.cabinet-office.gov.uk/"

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -11,7 +11,9 @@ public enum AuthenticationJourneyPages {
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
     ENTER_EMAIL_EXISTING_USER("/enter-email", "Sign in to your GOV.UK account"),
-    SHARE_INFO("/share-info", "Share information from your GOV.UK account");
+    SHARE_INFO("/share-info", "Share information from your GOV.UK account"),
+    SECURITY_CODE_INVALID(
+            "/security-code-invalid", "You entered the wrong security code too many times");
 
     private static final String PRODUCT_NAME = "GOV.UK account";
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
@@ -3,6 +3,9 @@ package uk.gov.di.test.acceptance;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -15,6 +18,8 @@ import java.net.URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SignInStepDefinitions {
+    protected static final String CHROME_BROWSER = "chrome";
+    protected static final String FIREFOX_BROWSER = "firefox";
     protected static final String SELENIUM_URL = System.getenv().get("SELENIUM_URL");
     protected static final URI IDP_URL =
             URI.create(System.getenv().getOrDefault("IDP_URL", "http://localhost:8080/"));
@@ -22,14 +27,34 @@ public class SignInStepDefinitions {
             URI.create(System.getenv().getOrDefault("RP_URL", "http://localhost:8081/"));
     protected static final URI AM_URL =
             URI.create(System.getenv().getOrDefault("AM_URL", "http://localhost:8081/"));
+    protected static final Boolean SELENIUM_LOCAL =
+            Boolean.parseBoolean(System.getenv().getOrDefault("SELENIUM_LOCAL", "false"));
+    protected static final String SELENIUM_BROWSER =
+            System.getenv().getOrDefault("SELENIUM_BROWSER", FIREFOX_BROWSER);
     protected static final int DEFAULT_PAGE_LOAD_WAIT_TIME = 20;
     protected static WebDriver driver;
 
     protected void setupWebdriver() throws MalformedURLException {
         if (driver == null) {
-            FirefoxOptions firefoxOptions = new FirefoxOptions();
-            firefoxOptions.setHeadless(true);
-            driver = new RemoteWebDriver(new URL(SELENIUM_URL), firefoxOptions);
+            switch (SELENIUM_BROWSER) {
+                case CHROME_BROWSER:
+                    ChromeOptions chromeOptions = new ChromeOptions();
+                    chromeOptions.setHeadless(SELENIUM_LOCAL);
+                    if (SELENIUM_LOCAL) {
+                        driver = new ChromeDriver(chromeOptions);
+                    } else {
+                        driver = new RemoteWebDriver(new URL(SELENIUM_URL), chromeOptions);
+                    }
+                    break;
+                default:
+                    FirefoxOptions firefoxOptions = new FirefoxOptions();
+                    firefoxOptions.setHeadless(SELENIUM_LOCAL);
+                    if (SELENIUM_LOCAL) {
+                        driver = new FirefoxDriver(firefoxOptions);
+                    } else {
+                        driver = new RemoteWebDriver(new URL(SELENIUM_URL), firefoxOptions);
+                    }
+            }
         }
     }
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
@@ -1,9 +1,34 @@
 Feature: Registration Journey
   New user walks through a registration journey
 
+  Scenario: User registration unsuccessful with invalid email, six digit code and password
+    Given the registration services are running
+    And the new user has an invalid email format
+    And the new user clears cookies
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user selects create an account
+    Then the new user is taken to the enter your email page
+    When the new user enters their email address
+    Then the new user is shown an error message
+    When the new user has a valid email address
+    And the new user enters their email address
+    Then the new user is asked to check their email
+    When the new user enters the six digit security code incorrectly 5 times
+#    -- Not testing the limit at the moment as this locks the account --
+#    Then the new user is taken to the security code invalid page
+    When a new user has valid credentials
+    When the new user enters the six digit security code from their email
+    Then the new user is taken to the create your password page
+    When the new user has an invalid password
+    And the new user creates a password
+    Then the new user is shown an error message
+
   Scenario: User successfully registers
     Given the registration services are running
     And a new user has valid credentials
+    And the new user clears cookies
     When the new user visits the stub relying party
     And the new user clicks "govuk-signin-button"
     Then the new user is taken to the Identity Provider Login Page
@@ -13,7 +38,7 @@ Feature: Registration Journey
     Then the new user is asked to check their email
     When the new user enters the six digit security code from their email
     Then the new user is taken to the create your password page
-    When the new user creates a valid password
+    When the new user creates a password
     Then the new user is taken to the enter phone number page
     When the new user enters their mobile phone number
     Then the new user is taken to the check your phone page

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,17 @@
 version: '3.8'
 
 services:
-  selenium:
+  selenium-firefox:
     image: selenium/standalone-firefox@sha256:4cee1e9d02dc0ff00683582a678a904991016a4534fa61bda2db11982d5094f4
     ports:
       - 4444:4444
     networks:
       - op-net
-
+  selenium-chrome:
+    image: selenium/standalone-chrome@sha256:36784cc22ea01886ac226146be343afe7d984d9fc69436e52c2c0f8fd0dc0f55
+    ports:
+      - 4445:4444
+    networks:
+      - op-net
 networks:
   op-net:

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -42,7 +42,7 @@ fi
 
 printf "\nRunning di-authentication-acceptance-tests...\n"
 
-start_docker_services selenium
+start_docker_services selenium-firefox selenium-chrome
 sleep 5
 
 export $(grep -v '^#' .env | xargs)


### PR DESCRIPTION
## What?

Add registration validation scenarios.

- Test invalid data for email address, six digit code and password in the signup journey.
- Add local support for testing in Chrome.

## Why?

Increase test and browser coverage.