### PR TITLE
BAU: add debug mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,14 @@
 # Update these environment variables to test the scenarios locally and rename to .env
+# firefox = 4444, chrome = 4445 
 SELENIUM_URL="http://localhost:4444/wd/hub"
+# Browser used to run tests - firefox|chrome
 SELENIUM_BROWSER=firefox
+# Run Selenium in a container (false) or on the local machine (true)
 SELENIUM_LOCAL=false
+# Run Selenium headless.  Set to false to see the tests run in a the browser
+SELENIUM_HEADLESS=true
+# debug mode waits for user entry on OTP screens so you can enter OTP yourself
+DEBUG_MODE=false
 IDP_URL="https://front.build.auth.ida.digital.cabinet-office.gov.uk/"
 RP_URL="https://di-auth-stub-relying-party-build-s2.london.cloudapps.digital/"
 AM_URL="https://account-management.build.auth.ida.digital.cabinet-office.gov.uk/"
@@ -10,3 +17,4 @@ TEST_USER_PASSWORD=
 TEST_USER_PHONE_NUMBER=
 TEST_USER_EMAIL_CODE=
 TEST_USER_PHONE_CODE=
+TEST_USER_NEW_PASSWORD=

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -7,6 +7,8 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -100,7 +102,16 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
     @When("the existing user enters the six digit security code from their phone")
     public void theExistingUserEntersTheSixDigitSecurityCodeFromTheirPhone() {
         WebElement sixDigitSecurityCodeField = driver.findElement(By.id("code"));
-        sixDigitSecurityCodeField.sendKeys(sixDigitCodePhone);
+        if (DEBUG_MODE) {
+            new WebDriverWait(driver, 60)
+                    .until(
+                            (ExpectedCondition<Boolean>)
+                                    driver ->
+                                            sixDigitSecurityCodeField.getAttribute("value").length()
+                                                    == 6);
+        } else {
+            sixDigitSecurityCodeField.sendKeys(sixDigitCodePhone);
+        }
         findAndClickContinue();
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -7,6 +7,8 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -145,7 +147,16 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     public void theNewUserEntersTheSixDigitSecurityCodeFromTheirEmail() {
         WebElement sixDigitSecurityCodeField = driver.findElement(By.id("code"));
         sixDigitSecurityCodeField.clear();
-        sixDigitSecurityCodeField.sendKeys(sixDigitCodeEmail);
+        if (DEBUG_MODE) {
+            new WebDriverWait(driver, 60)
+                    .until(
+                            (ExpectedCondition<Boolean>)
+                                    driver ->
+                                            sixDigitSecurityCodeField.getAttribute("value").length()
+                                                    == 6);
+        } else {
+            sixDigitSecurityCodeField.sendKeys(sixDigitCodeEmail);
+        }
         findAndClickContinue();
     }
 
@@ -188,7 +199,16 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     @When("the new user enters the six digit security code from their phone")
     public void theNewUserEntersTheSixDigitSecurityCodeFromTheirPhone() {
         WebElement sixDigitSecurityCodeField = driver.findElement(By.id("code"));
-        sixDigitSecurityCodeField.sendKeys(sixDigitCodePhone);
+        if (DEBUG_MODE) {
+            new WebDriverWait(driver, 60)
+                    .until(
+                            (ExpectedCondition<Boolean>)
+                                    driver ->
+                                            sixDigitSecurityCodeField.getAttribute("value").length()
+                                                    == 6);
+        } else {
+            sixDigitSecurityCodeField.sendKeys(sixDigitCodePhone);
+        }
         findAndClickContinue();
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
@@ -29,6 +29,10 @@ public class SignInStepDefinitions {
             URI.create(System.getenv().getOrDefault("AM_URL", "http://localhost:8081/"));
     protected static final Boolean SELENIUM_LOCAL =
             Boolean.parseBoolean(System.getenv().getOrDefault("SELENIUM_LOCAL", "false"));
+    protected static final Boolean SELENIUM_HEADLESS =
+            Boolean.parseBoolean(System.getenv().getOrDefault("SELENIUM_HEADLESS", "true"));
+    protected static final Boolean DEBUG_MODE =
+            Boolean.parseBoolean(System.getenv().getOrDefault("DEBUG_MODE", "false"));
     protected static final String SELENIUM_BROWSER =
             System.getenv().getOrDefault("SELENIUM_BROWSER", FIREFOX_BROWSER);
     protected static final int DEFAULT_PAGE_LOAD_WAIT_TIME = 20;
@@ -39,7 +43,7 @@ public class SignInStepDefinitions {
             switch (SELENIUM_BROWSER) {
                 case CHROME_BROWSER:
                     ChromeOptions chromeOptions = new ChromeOptions();
-                    chromeOptions.setHeadless(SELENIUM_LOCAL);
+                    chromeOptions.setHeadless(SELENIUM_HEADLESS);
                     if (SELENIUM_LOCAL) {
                         driver = new ChromeDriver(chromeOptions);
                     } else {
@@ -48,7 +52,7 @@ public class SignInStepDefinitions {
                     break;
                 default:
                     FirefoxOptions firefoxOptions = new FirefoxOptions();
-                    firefoxOptions.setHeadless(SELENIUM_LOCAL);
+                    firefoxOptions.setHeadless(SELENIUM_HEADLESS);
                     if (SELENIUM_LOCAL) {
                         driver = new FirefoxDriver(firefoxOptions);
                     } else {


### PR DESCRIPTION
## What?

Add debug mode

- Let tester interact with a local browser when running the tests.
- Pauses to let tester enter OTP codes.

Separate flag for headless mode.

## Why?

Provide a configurable way to build and test scenarios in a local browser.