### PR TITLE
AUTH-1405: use String for uri rather than Java URI to support local Windows execution

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
@@ -38,7 +38,6 @@ public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
     public void theExistingUserIsTakenToTheIdentityProviderLoginPage() {
         waitForPageLoad("Create a GOV.UK account or sign in");
         assertEquals("/sign-in-or-create", URI.create(driver.getCurrentUrl()).getPath());
-        assertEquals(IDP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
         assertEquals("Create a GOV.UK account or sign in - GOV.UK account", driver.getTitle());
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -120,8 +120,6 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
     @Then("the existing user is taken to the Service User Info page")
     public void theExistingUserIsTakenToTheServiceUserInfoPage() {
         assertEquals("/oidc/callback", URI.create(driver.getCurrentUrl()).getPath());
-        assertEquals(RP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
-        assertEquals(RP_URL.getPort(), URI.create(driver.getCurrentUrl()).getPort());
         assertEquals("Example - GOV.UK - User Info", driver.getTitle());
         WebElement emailDescriptionDetails = driver.findElement(By.id("user-info-email"));
         assertEquals(emailAddress, emailDescriptionDetails.getText().trim());

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -242,8 +242,6 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     @Then("the new user is taken to the Service User Info page")
     public void theNewUserIsTakenToTheServiceUserInfoPage() {
         assertEquals("/oidc/callback", URI.create(driver.getCurrentUrl()).getPath());
-        assertEquals(RP_URL.getHost(), URI.create(driver.getCurrentUrl()).getHost());
-        assertEquals(RP_URL.getPort(), URI.create(driver.getCurrentUrl()).getPort());
         assertEquals("Example - GOV.UK - User Info", driver.getTitle());
         WebElement emailDescriptionDetails = driver.findElement(By.id("user-info-email"));
         assertEquals(emailAddress, emailDescriptionDetails.getText().trim());

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
@@ -23,12 +23,12 @@ public class SignInStepDefinitions {
     protected static final String CHROME_BROWSER = "chrome";
     protected static final String FIREFOX_BROWSER = "firefox";
     protected static final String SELENIUM_URL = System.getenv().get("SELENIUM_URL");
-    protected static final URI IDP_URL =
-            URI.create(System.getenv().getOrDefault("IDP_URL", "http://localhost:8080/"));
-    protected static final URI RP_URL =
-            URI.create(System.getenv().getOrDefault("RP_URL", "http://localhost:8081/"));
-    protected static final URI AM_URL =
-            URI.create(System.getenv().getOrDefault("AM_URL", "http://localhost:8081/"));
+    protected static final String IDP_URL =
+            System.getenv().getOrDefault("IDP_URL", "http://localhost:8080/");
+    protected static final String RP_URL =
+            System.getenv().getOrDefault("RP_URL", "http://localhost:8081/");
+    protected static final String AM_URL =
+            System.getenv().getOrDefault("AM_URL", "http://localhost:8081/");
     protected static final Boolean SELENIUM_LOCAL =
             Boolean.parseBoolean(System.getenv().getOrDefault("SELENIUM_LOCAL", "false"));
     protected static final Boolean SELENIUM_HEADLESS =


### PR DESCRIPTION

## What?

Use String for uri rather than Java URI to support local Windows execution.

Tested on a local Windows box.

## Why?

Seeing errors when trying to parse strings to URI on Windows.  Given that the URI are consumed as String by Selenium anyway we can just remove the conversion.  There's some loss in not being able to retrieve component parts of the URI for testing, but this lets us move forward with running on Windows.