### PR TITLE
AUTH-1414: acceptance tests with existing email

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
@@ -9,7 +9,8 @@ public enum AccountJourneyPages {
     ENTER_PASSWORD_DELETE_ACCOUNT("/enter-password", "Enter your password"),
     DELETE_ACCOUNT("/delete-account", "Are you sure you want to delete your account?"),
     ACCOUNT_DELETED_CONFIRMATION(
-            "/account-deleted-confirmation", "You have deleted your GOV.UK account");
+            "/account-deleted-confirmation", "You have deleted your GOV.UK account"),
+    ACCOUNT_EXISTS("/enter-password-account-exists", "You have a GOV.UK account");
 
     private static final String PRODUCT_NAME = "GOV.UK account";
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -13,6 +13,7 @@ import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ACCOUNT_DELETED_CONFIRMATION;
+import static uk.gov.di.test.acceptance.AccountJourneyPages.ACCOUNT_EXISTS;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.CHANGE_PASSWORD;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.DELETE_ACCOUNT;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_CHANGE_PASSWORD;
@@ -122,5 +123,28 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
         waitForPageLoad(page.getShortTitle());
         assertEquals(page.getRoute(), URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(page.getFullTitle(), driver.getTitle());
+    }
+
+    @And("the existing account management user selects create an account")
+    public void theExistingAccountManagementUserSelectsCreateAnAccount() {
+        WebElement link = driver.findElement(By.id("create-account-link"));
+        link.click();
+    }
+
+    @Then("the exiting account management user is asked to enter their current email address")
+    public void theExitingAccountManagementUserIsAskedToEnterTheirCurrentEmailAddress() {
+        waitForPageLoadThenValidate(AuthenticationJourneyPages.ENTER_EMAIL_CREATE);
+    }
+
+    @When("the existing account management user enters their current email address")
+    public void theExistingAccountManagementUserEntersTheirCurrentEmailAddress() {
+        WebElement passwordField = driver.findElement(By.id("email"));
+        passwordField.sendKeys(emailAddress);
+        findAndClickContinue();
+    }
+
+    @Then("the existing account management user is taken to the account exists page")
+    public void theExistingAccountManagementUserIsTakenToTheAccountExistsPage() {
+        waitForPageLoadThenValidate(ACCOUNT_EXISTS);
     }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -1,6 +1,15 @@
 Feature: Login Journey
   Existing user walks through a login journey
 
+  Scenario: Existing user tries to create an account with the same email address
+    Given the account management services are running
+    And the existing account management user has valid credentials
+    When the existing account management user navigates to account management
+    And the existing account management user selects create an account
+    Then the exiting account management user is asked to enter their current email address
+    When the existing account management user enters their current email address
+    Then the existing account management user is taken to the account exists page
+
   Scenario: Existing user is correctly prompted to login
     Given the login services are running
     And the existing user has valid credentials
@@ -31,6 +40,8 @@ Feature: Login Journey
       When the existing account management user clicks link by href "/manage-your-account"
       Then the existing account management user is taken to the manage your account page
 
+
+
   Scenario: User deletes their account
       Given the account management services are running
       And the existing account management user has valid credentials
@@ -45,3 +56,4 @@ Feature: Login Journey
       Then the existing account management user is taken to the account deleted confirmation page
       When the not logged in user navigates to account root
       Then the not logged in user is taken to the Identity Provider Login Page
+


### PR DESCRIPTION
## What?

Acceptance tests for scenario #7 on the spreadsheet. Where an existing user tries to create an account even though they already have an account.

## Why?

Need to increase coverage of automation and this scenario is required.
