### PR TITLE
GOVSI-1190: update account created page title in test

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -9,7 +9,7 @@ public enum AuthenticationJourneyPages {
     CREATE_PASSWORD("/create-password", "Create your password"),
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
-    ACCOUNT_CREATED("/account-created", "You have created your GOV.UK account"),
+    ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
     ENTER_EMAIL_EXISTING_USER("/enter-email", "Sign in to your GOV.UK account"),

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -208,9 +208,7 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     @When("the new user clicks the continue link")
     public void theNewUserClicksTheGoBackToGovUkLink() {
         WebElement goBackLink =
-                driver.findElement(
-                        By.xpath(
-                                "//a[text()[normalize-space() = 'Continue']]"));
+                driver.findElement(By.xpath("//a[text()[normalize-space() = 'Continue']]"));
         goBackLink.click();
     }
 


### PR DESCRIPTION
## What?

Update account created page title in test.

## Why?

Account created page title was changed so this needs to be reflected in the test.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/532