### PR TITLE
AUTH-1134: acceptance tests abandon before 2 fa setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ logs/
 .settings/
 bin/
 .env
+*.bat
+node_modules/

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -9,7 +9,7 @@ public enum AuthenticationJourneyPages {
     CREATE_PASSWORD("/create-password", "Create your password"),
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
-    ACCOUNT_CREATED("/account-created", "You have created your GOV.UK account"),
+    ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
     ENTER_EMAIL_EXISTING_USER("/enter-email", "Sign in to your GOV.UK account"),

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PASSWORD;
+import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PHONE_NUMBER;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.SIGN_IN_OR_CREATE;
 
 public class LoginStepDefinitions extends SignInStepDefinitions {
@@ -129,5 +130,10 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
     public void theExistingUserIsShownAnErrorMessageOnTheEnterEmailPage() {
         WebElement emailDescriptionDetails = driver.findElement(By.id("error-summary-title"));
         assertTrue(emailDescriptionDetails.isDisplayed());
+    }
+
+    @Then("the existing user is taken to the enter phone number page")
+    public void theExistingUserIsTakenToTheEnterPhoneNumberPage() {
+        waitForPageLoadThenValidate(ENTER_PHONE_NUMBER);
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -205,12 +205,10 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         waitForPageLoadThenValidate(ACCOUNT_CREATED);
     }
 
-    @When("the new user clicks the go back to gov.uk link")
+    @When("the new user clicks the continue link")
     public void theNewUserClicksTheGoBackToGovUkLink() {
         WebElement goBackLink =
-                driver.findElement(
-                        By.xpath(
-                                "//a[text()[normalize-space() = 'Go back to GOV.UK to continue']]"));
+                driver.findElement(By.xpath("//a[text()[normalize-space() = 'Continue']]"));
         goBackLink.click();
     }
 
@@ -266,5 +264,12 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
             randomCode = String.format("%06d", new Random().nextInt(999999));
         } while (randomCode.equals(sixDigitCodeEmail));
         return randomCode;
+    }
+
+    @And("the new user enters their password")
+    public void theNewUserEntersTheirPassword() {
+        WebElement enterPasswordField = driver.findElement(By.id("password"));
+        enterPasswordField.sendKeys(password);
+        findAndClickContinue();
     }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
@@ -29,7 +29,7 @@ Feature: Registration Journey
     When the new user has a valid email address
     And the new user enters their email address
     Then the new user is asked to check their email
-    When the new user enters the six digit security code incorrectly 5 times
+#    When the new user enters the six digit security code incorrectly 5 times
 #    -- Not testing the limit at the moment as this locks the account --
 #    Then the new user is taken to the security code invalid page
     When a new user has valid credentials
@@ -58,7 +58,7 @@ Feature: Registration Journey
     Then the new user is taken to the check your phone page
     When the new user enters the six digit security code from their phone
     Then the new user is taken to the account created page
-    When the new user clicks the go back to gov.uk link
+    When the new user clicks the continue link
     Then the new user is taken the the share info page
     When the new user agrees to share their info
     Then the new user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -40,8 +40,6 @@ Feature: Login Journey
       When the existing account management user clicks link by href "/manage-your-account"
       Then the existing account management user is taken to the manage your account page
 
-
-
   Scenario: User deletes their account
       Given the account management services are running
       And the existing account management user has valid credentials

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
@@ -1,0 +1,41 @@
+Feature: Incomplete registration
+  New user leaves the registration journey before completing it
+
+  Scenario: Abandon before 2FA setup
+    Given the registration services are running
+    And a new user has valid credentials
+    And the new user clears cookies
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user selects create an account
+    Then the new user is taken to the enter your email page
+    When the new user enters their email address
+    Then the new user is asked to check their email
+    When the new user enters the six digit security code from their email
+    Then the new user is taken to the create your password page
+    When the new user creates a password
+    Then the new user is taken to the enter phone number page
+    When the new user enters their mobile phone number
+    Then the new user is taken to the check your phone page
+    When the new user visits the stub relying party
+    And a new user has valid credentials
+    And the new user clears cookies
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user selects sign in
+    When the new user enters their email address
+    When the new user enters their password
+    Then the new user is taken to the enter phone number page
+    When the new user enters their mobile phone number
+    Then the new user is taken to the check your phone page
+    When the new user enters the six digit security code from their phone
+    Then the new user is taken to the account created page
+    When the new user clicks the continue link
+    Then the new user is taken the the share info page
+    When the new user agrees to share their info
+    Then the new user is returned to the service
+    When the new user clicks link by href "https://build.account.gov.uk"
+    When the new user clicks link by href "/enter-password?type=deleteAccount"
+    When the new user enters their password
+    When the user clicks button by text Delete account


### PR DESCRIPTION
## What?

Added a new feature to cover a scenario where a user abandons registration before 2FA setup. Followed by completion of registration to allow the account to be deleted, so local runs are kept smooth. 

## Why?

To include coverage of high priority candidates for automation.