### PR TITLE
Auth 1323 acceptance tests account locked scenarios

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -205,11 +205,10 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         waitForPageLoadThenValidate(ACCOUNT_CREATED);
     }
 
-    @When("the new user clicks the continue link")
-    public void theNewUserClicksTheGoBackToGovUkLink() {
-        WebElement goBackLink =
-                driver.findElement(By.xpath("//a[text()[normalize-space() = 'Continue']]"));
-        goBackLink.click();
+    @When("the new user clicks the continue button")
+    public void theNewUserClicksTheGoBackToGovUkButton() {
+        WebElement goBackButton = driver.findElement(By.cssSelector("#form-tracking > button"));
+        goBackButton.click();
     }
 
     @Then("the new user is taken the the share info page")
@@ -270,6 +269,37 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     public void theNewUserEntersTheirPassword() {
         WebElement enterPasswordField = driver.findElement(By.id("password"));
         enterPasswordField.sendKeys(password);
+        findAndClickContinue();
+    }
+
+    @And("the new email code lock user has valid credentials")
+    public void theNewEmailCodeLockUserHasValidCredentials() {
+        emailAddress = System.getenv().get("EMAIL_CODE_LOCK_TEST_USER_EMAIL");
+        password = System.getenv().get("TEST_USER_PASSWORD");
+        phoneNumber = System.getenv().get("TEST_USER_PHONE_NUMBER");
+    }
+
+    @And("the new phone code lock user has valid credentials")
+    public void theNewPhoneCodeLockUserHasValidCredentials() {
+        emailAddress = System.getenv().get("PHONE_CODE_LOCK_TEST_USER_EMAIL");
+        password = System.getenv().get("TEST_USER_PASSWORD");
+        phoneNumber = System.getenv().get("TEST_USER_PHONE_NUMBER");
+        sixDigitCodeEmail = System.getenv().get("TEST_USER_EMAIL_CODE");
+    }
+
+    @When("the new user enters an incorrect email code one more time")
+    public void theNewUserEntersAnIncorrectEmailCodeOneMoreTime() {
+        WebElement enterCodeField = driver.findElement(By.id("code"));
+        enterCodeField.clear();
+        enterCodeField.sendKeys(getRandomInvalidCode());
+        findAndClickContinue();
+    }
+
+    @When("the new user enters an incorrect phone code one more time")
+    public void theNewUserEntersAnIncorrectPhoneCodeOneMoreTime() {
+        WebElement enterCodeField = driver.findElement(By.id("code"));
+        enterCodeField.clear();
+        enterCodeField.sendKeys(getRandomInvalidCode());
         findAndClickContinue();
     }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
@@ -29,9 +29,6 @@ Feature: Registration Journey
     When the new user has a valid email address
     And the new user enters their email address
     Then the new user is asked to check their email
-#    When the new user enters the six digit security code incorrectly 5 times
-#    -- Not testing the limit at the moment as this locks the account --
-#    Then the new user is taken to the security code invalid page
     When a new user has valid credentials
     When the new user enters the six digit security code from their email
     Then the new user is taken to the create your password page
@@ -58,7 +55,7 @@ Feature: Registration Journey
     Then the new user is taken to the check your phone page
     When the new user enters the six digit security code from their phone
     Then the new user is taken to the account created page
-    When the new user clicks the continue link
+    When the new user clicks the continue button
     Then the new user is taken the the share info page
     When the new user agrees to share their info
     Then the new user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
@@ -31,7 +31,7 @@ Feature: Incomplete registration
     Then the new user is taken to the check your phone page
     When the new user enters the six digit security code from their phone
     Then the new user is taken to the account created page
-    When the new user clicks the continue link
+    When the new user clicks the continue button
     Then the new user is taken the the share info page
     When the new user agrees to share their info
     Then the new user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
@@ -1,0 +1,61 @@
+Feature: Locked accounts
+  Existing users get locked out of their accounts
+
+  Scenario: New user enters incorrect email code 6 times
+    Given the login services are running
+    And the new email code lock user has valid credentials
+    And the new user clears cookies
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user selects create an account
+    Then the new user is taken to the enter your email page
+    When the new user enters their email address
+    Then the new user is asked to check their email
+    When the new user enters the six digit security code incorrectly 5 times
+    When the new user enters an incorrect email code one more time
+    Then the new user is taken to the security code invalid page
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user selects sign in
+    Then the new user is taken to the sign in to your account page
+    When the new user enters their email address
+    Then the new user is taken to the account not found page
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user selects create an account
+    Then the new user is taken to the enter your email page
+    When the new user enters their email address
+    Then the new user is taken to the security code invalid page
+
+  Scenario: New user enters incorrect phone code 6 times
+    Given the login services are running
+    And the new phone code lock user has valid credentials
+    And the new user clears cookies
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user selects create an account
+    Then the new user is taken to the enter your email page
+    When the new user enters their email address
+    Then the new user is asked to check their email
+    When the new user enters the six digit security code from their email
+    Then the new user is taken to the create your password page
+    When the new user creates a password
+    Then the new user is taken to the enter phone number page
+    When the new user enters their mobile phone number
+    Then the new user is taken to the check your phone page
+    When the new user enters the six digit security code incorrectly 5 times
+    When the new user enters an incorrect phone code one more time
+    Then the new user is taken to the security code invalid page
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user selects sign in
+    Then the new user is taken to the sign in to your account page
+    When the new user enters their email address
+    When the new user enters their password
+    When the new user enters their mobile phone number
+    Then the new user is taken to the security code invalid page


### PR DESCRIPTION
## What?

Extension of the RegistrationStepDefinitions class and addition of a new feature to cover the email and SMS OTPs being incorrectly entered 6 times, resulting in accounts being locked.

## Why?

To expand automation of high priority user journeys. 

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.