### PR TITLE
Aut 442 add password validation error scenarios

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -54,8 +54,11 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         password = "password1";
     }
 
-    @When("the new user has a digit only password")
-    public void theNewUserHasADigitOnlyPassword() { password = "44445555"; }
+    @When("the new user has a short digit only password")
+    public void theNewUserHasAShortDigitOnlyPassword() { password = "44445555"; }
+
+    @When("the new user has a sequence of numbers password")
+    public void theNewUserHasASequenceOfNumbersPassword() { password = "12345678";}
 
     @And("a new user has valid credentials")
     public void theNewUserHasValidCredential() {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -49,6 +49,14 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         password = "password";
     }
 
+    @When("the new user has a weak password")
+    public void theUserHasAWeakPassword() {
+        password = "password1";
+    }
+
+    @When("the new user has a digit only password")
+    public void theNewUserHasADigitOnlyPassword() { password = "44445555"; }
+
     @And("a new user has valid credentials")
     public void theNewUserHasValidCredential() {
         emailAddress = System.getenv().get("TEST_USER_EMAIL");

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
@@ -37,6 +37,12 @@ Feature: Registration Journey
     And the new user creates a password
     And there are no accessibility violations
     Then the new user is shown an error message
+    When the new user has a weak password
+    And the new user creates a password
+    Then the new user is shown an error message
+    When the new user has a digit only password
+    And the new user creates a password
+    Then the new user is shown an error message
 
   Scenario: User successfully registers
     Given the registration services are running

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
@@ -40,7 +40,10 @@ Feature: Registration Journey
     When the new user has a weak password
     And the new user creates a password
     Then the new user is shown an error message
-    When the new user has a digit only password
+    When the new user has a short digit only password
+    And the new user creates a password
+    Then the new user is shown an error message
+    When the new user has a sequence of numbers password
     And the new user creates a password
     Then the new user is shown an error message
 


### PR DESCRIPTION
## What?

Added a few more error scenarios to password validation

## Why?

Thinking ahead of the changes coming to the FE for top 100K passwords it will come in handy for password validation regression. Also, I wanted to add these sub-scenarios a while back but it got left on the back burner.