### PR TITLE
AC tests fix - abandon before 2FA setup scenario

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -8,6 +8,7 @@ public enum AuthenticationJourneyPages {
     CHECK_YOUR_EMAIL("/check-your-email", "Check your email"),
     CREATE_PASSWORD("/create-password", "Create your password"),
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
+    FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
     ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -21,6 +21,7 @@ import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PASSWORD;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PHONE_NUMBER;
+import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.FINISH_CREATING_YOUR_ACCOUNT;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.SIGN_IN_OR_CREATE;
 
 public class LoginStepDefinitions extends SignInStepDefinitions {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -55,10 +55,14 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     }
 
     @When("the new user has a short digit only password")
-    public void theNewUserHasAShortDigitOnlyPassword() { password = "44445555"; }
+    public void theNewUserHasAShortDigitOnlyPassword() {
+        password = "44445555";
+    }
 
     @When("the new user has a sequence of numbers password")
-    public void theNewUserHasASequenceOfNumbersPassword() { password = "12345678";}
+    public void theNewUserHasASequenceOfNumbersPassword() {
+        password = "12345678";
+    }
 
     @And("a new user has valid credentials")
     public void theNewUserHasValidCredential() {
@@ -187,6 +191,11 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     @Then("the new user is taken to the enter phone number page")
     public void theNewUserIsTakenToTheEnterPhoneNumberPage() {
         waitForPageLoadThenValidate(ENTER_PHONE_NUMBER);
+    }
+
+    @Then("the new user is taken to the finish creating your account page")
+    public void theNewUserIsTakenToTheFinishCreatingYourAccountPage() {
+        waitForPageLoadThenValidate(FINISH_CREATING_YOUR_ACCOUNT);
     }
 
     @When("the new user enters their mobile phone number")

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
@@ -26,7 +26,7 @@ Feature: Incomplete registration
     When the new user selects sign in
     When the new user enters their email address
     When the new user enters their password
-    Then the new user is taken to the enter phone number page
+    Then the new user is taken to the finish creating your account page
     When the new user enters their mobile phone number
     Then the new user is taken to the check your phone page
     When the new user enters the six digit security code from their phone


### PR DESCRIPTION
## What?

Adding additional step definition and other bits to cater for change of content on abandon before 2FA setup scenario.

## Why?

To enable the AC tests to run successfully again

