### PR TITLE
Ac tests title change tweak

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
@@ -1,7 +1,7 @@
 package uk.gov.di.test.acceptance;
 
 public enum AccountJourneyPages {
-    MANAGE_YOUR_ACCOUNT("/manage-your-account", "Manage your account"),
+    YOUR_GOV_UK_ACCOUNT("/manage-your-account", "Your GOV.UK account"),
     ENTER_PASSWORD_CHANGE_PASSWORD("/enter-password", "Enter your current password"),
     CHANGE_PASSWORD("/change-password", "Enter your new password"),
     PASSWORD_UPDATED_CONFIRMATION(

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -20,7 +20,7 @@ import static uk.gov.di.test.acceptance.AccountJourneyPages.DELETE_ACCOUNT;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_NEW_MOBILE_PHONE_NUMBER;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_CHANGE_PASSWORD;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_DELETE_ACCOUNT;
-import static uk.gov.di.test.acceptance.AccountJourneyPages.MANAGE_YOUR_ACCOUNT;
+import static uk.gov.di.test.acceptance.AccountJourneyPages.YOUR_GOV_UK_ACCOUNT;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.PASSWORD_UPDATED_CONFIRMATION;
 
 public class AccountManagementStepDefinitions extends SignInStepDefinitions {
@@ -50,9 +50,9 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
         driver.get(AM_URL.toString());
     }
 
-    @Then("the existing account management user is taken to the manage your account page")
-    public void theExistingAccountManagementUserIsTakenToTheManageYourAccountPage() {
-        waitForPageLoadThenValidate(MANAGE_YOUR_ACCOUNT);
+    @Then("the existing account management user is taken to the your gov uk account page")
+    public void theExistingAccountManagementUserIsTakenToTheYourGovUkAccountPage() {
+        waitForPageLoadThenValidate(YOUR_GOV_UK_ACCOUNT);
     }
 
     @When("the existing account management user clicks link by href {string}")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -20,8 +20,8 @@ import static uk.gov.di.test.acceptance.AccountJourneyPages.DELETE_ACCOUNT;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_NEW_MOBILE_PHONE_NUMBER;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_CHANGE_PASSWORD;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_DELETE_ACCOUNT;
-import static uk.gov.di.test.acceptance.AccountJourneyPages.YOUR_GOV_UK_ACCOUNT;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.PASSWORD_UPDATED_CONFIRMATION;
+import static uk.gov.di.test.acceptance.AccountJourneyPages.YOUR_GOV_UK_ACCOUNT;
 
 public class AccountManagementStepDefinitions extends SignInStepDefinitions {
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -54,7 +54,7 @@ Feature: Login Journey
     Given the account management services are running
     And the existing account management user has valid credentials
     When the existing account management user navigates to account management
-    Then the existing account management user is taken to the manage your account page
+    Then the existing account management user is taken to the your gov uk account page
     When the existing account management user clicks link by href "/enter-password?type=changePhoneNumber"
     Then the existing account management user is asked to enter their password
     When the existing account management user enter their current password
@@ -62,13 +62,13 @@ Feature: Login Journey
     When the existing account management user enters their existing mobile phone number
     Then the existing account management user is shown an error message
     When the existing account management user clicks link by href "/manage-your-account"
-    Then the existing account management user is taken to the manage your account page
+    Then the existing account management user is taken to the your gov uk account page
 
   Scenario: User changes their password
       Given the account management services are running
       And the existing account management user has valid credentials
       When the existing account management user navigates to account management
-      Then the existing account management user is taken to the manage your account page
+      Then the existing account management user is taken to the your gov uk account page
       When the existing account management user clicks link by href "/enter-password?type=changePassword"
       Then the existing account management user is asked to enter their current password
       When the existing account management user enter their current password
@@ -77,13 +77,13 @@ Feature: Login Journey
       And the existing account management user enters their updated password
       Then the existing account management user is taken to password updated confirmation page
       When the existing account management user clicks link by href "/manage-your-account"
-      Then the existing account management user is taken to the manage your account page
+      Then the existing account management user is taken to the your gov uk account page
 
   Scenario: User deletes their account
       Given the account management services are running
       And the existing account management user has valid credentials
       When the existing account management user navigates to account management
-      Then the existing account management user is taken to the manage your account page
+      Then the existing account management user is taken to the your gov uk account page
       When the existing account management user clicks link by href "/enter-password?type=deleteAccount"
       Then the existing account management user is asked to enter their password
       When the existing account management user uses their updated password


### PR DESCRIPTION
## What?

Fix to enable the tests to run again

## Why?

Due to changes to the title of the manage your account page in account management.
