### PR TITLE
AC tests - Changes related to cookies policy page

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LegalAndPolicyPagesStepDefinitions.java
@@ -53,7 +53,7 @@ public class LegalAndPolicyPagesStepDefinitions extends SignInStepDefinitions {
 
     @Then("the user is taken to the GOV.UK cookies page")
     public void theUserIsTakenToTheGOVUKCookiesPage() {
-        checkPageLoadInTabAndClose(SupportingPages.GOV_UK_COOKIES);
+        checkPageLoadInTabAndClose(SupportingPages.GOV_UK_ACCOUNTS_COOKIES);
     }
 
     @Then("the user is taken to the terms and conditions page")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SupportingPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SupportingPages.java
@@ -3,7 +3,7 @@ package uk.gov.di.test.acceptance;
 public enum SupportingPages {
     ACCESSIBILITY_STATEMENT(
             "/accessibility-statement", "Accessibility statement for GOV.UK accounts"),
-    GOV_UK_COOKIES("/help/cookies", "Cookies on GOV.UK"),
+    GOV_UK_ACCOUNTS_COOKIES("/cookies", "GOV.UK accounts cookies policy"),
     TERMS_AND_CONDITIONS("/terms-and-conditions", "Terms and conditions"),
     PRIVACY_NOTICE("/privacy-notice", "Privacy notice");
 


### PR DESCRIPTION
## What?

Change to cookies policy constant, route, title in SupportingPages class.

## Why?

To allow the AC tests to run with required changes following Daniel's implementation.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.