### PR TITLE
Aut 48 acceptance tests delete account invalid password

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
@@ -7,7 +7,7 @@ public enum AccountJourneyPages {
     PASSWORD_UPDATED_CONFIRMATION(
             "/password-updated-confirmation", "You have changed your password"),
     ENTER_PASSWORD_DELETE_ACCOUNT("/enter-password", "Enter your password"),
-    ENTER_PASSWORD_DELETE_ACCOUNT_FAILED("/enter password", "Error - Enter your password"),
+    ENTER_PASSWORD_DELETE_ACCOUNT_FAILED("/enter-password", "Error - Enter your password"),
     DELETE_ACCOUNT("/delete-account", "Are you sure you want to delete your account?"),
     ACCOUNT_DELETED_CONFIRMATION(
             "/account-deleted-confirmation", "You have deleted your GOV.UK account"),

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
@@ -7,6 +7,7 @@ public enum AccountJourneyPages {
     PASSWORD_UPDATED_CONFIRMATION(
             "/password-updated-confirmation", "You have changed your password"),
     ENTER_PASSWORD_DELETE_ACCOUNT("/enter-password", "Enter your password"),
+    ENTER_PASSWORD_DELETE_ACCOUNT_FAILED("/enter password", "Error - Enter your password"),
     DELETE_ACCOUNT("/delete-account", "Are you sure you want to delete your account?"),
     ACCOUNT_DELETED_CONFIRMATION(
             "/account-deleted-confirmation", "You have deleted your GOV.UK account"),

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -20,6 +20,7 @@ import static uk.gov.di.test.acceptance.AccountJourneyPages.DELETE_ACCOUNT;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_NEW_MOBILE_PHONE_NUMBER;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_CHANGE_PASSWORD;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_DELETE_ACCOUNT;
+import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_DELETE_ACCOUNT_FAILED;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.PASSWORD_UPDATED_CONFIRMATION;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.YOUR_GOV_UK_ACCOUNT;
 
@@ -176,5 +177,10 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
         WebElement enterPasswordField = driver.findElement(By.id("password"));
         enterPasswordField.sendKeys(password);
         findAndClickContinue();
+    }
+
+    @And("the existing account management user is asked to enter their password again")
+    public void theExistingAccountManagementUserIsAskedToEnterTheirPasswordAgain() {
+        waitForPageLoadThenValidate(ENTER_PASSWORD_DELETE_ACCOUNT_FAILED);
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -170,4 +170,11 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
         WebElement emailDescriptionDetails = driver.findElement(By.id("error-summary-title"));
         assertTrue(emailDescriptionDetails.isDisplayed());
     }
+
+    @When("the existing account management user enters an invalid password to delete account")
+    public void theExistingAccountManagementUserEntersAnInvalidPasswordToDeleteAccount() {
+        WebElement enterPasswordField = driver.findElement(By.id("password"));
+        enterPasswordField.sendKeys(password);
+        findAndClickContinue();
+    }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -79,6 +79,17 @@ Feature: Login Journey
       When the existing account management user clicks link by href "/manage-your-account"
       Then the existing account management user is taken to the your gov uk account page
 
+  Scenario: User fails deleting their account due to invalid password
+    Given the account management services are running
+    And the existing account management user has valid credentials
+    When the existing account management user navigates to account management
+    Then the existing account management user is taken to the your gov uk account page
+    When the existing account management user clicks link by href "/enter-password?type=deleteAccount"
+    Then the existing account management user is asked to enter their password
+    When the existing account management user enters an invalid password to delete account
+    Then the existing account management user is shown an error message
+    And the existing account management user is asked to enter their password
+
   Scenario: User deletes their account
       Given the account management services are running
       And the existing account management user has valid credentials

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -88,7 +88,7 @@ Feature: Login Journey
     Then the existing account management user is asked to enter their password
     When the existing account management user enters an invalid password to delete account
     Then the existing account management user is shown an error message
-    And the existing account management user is asked to enter their password
+    And the existing account management user is asked to enter their password again
 
   Scenario: User deletes their account
       Given the account management services are running


### PR DESCRIPTION
## What?

AC test for error scenario during account deletion where a user enters an invalid password and is prompted to enter their password again.

## Why?

To increase coverage and fulfill backlog item https://govukverify.atlassian.net/browse/AUT-48
