### PR TITLE
Added a reject consent step in the incomplete registration feature

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -343,4 +343,11 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         enterPasswordField.sendKeys(tcPassword);
         findAndClickContinue();
     }
+
+    @When("the new user does not agree to share their info")
+    public void theNewUserDoesNotAgreeToShareTheirInfo() {
+        WebElement radioShareInfoReject = driver.findElement(By.id("share-info-rejected"));
+        radioShareInfoReject.click();
+        findAndClickContinue();
+    }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
@@ -33,7 +33,7 @@ Feature: Incomplete registration
     Then the new user is taken to the account created page
     When the new user clicks the continue button
     Then the new user is taken the the share info page
-    When the new user agrees to share their info
+    When the new user does not agree to share their info
     Then the new user is returned to the service
     When the new user clicks link by href "https://build.account.gov.uk"
     When the new user clicks link by href "/enter-password?type=deleteAccount"


### PR DESCRIPTION
## What?

Addition of a feature step and step definition to cater for scenario where users reject consent to share (not on Prod atm). 

## Why?

To fulfil backlog item AUT-46, and also because it's a good one to have should it ever be enabled on Production.