### PR TITLE
Aut 593 acceptance tests save cookie settings

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountJourneyPages.java
@@ -12,7 +12,8 @@ public enum AccountJourneyPages {
     ACCOUNT_DELETED_CONFIRMATION(
             "/account-deleted-confirmation", "You have deleted your GOV.UK account"),
     ACCOUNT_EXISTS("/enter-password-account-exists", "You have a GOV.UK account"),
-    ENTER_NEW_MOBILE_PHONE_NUMBER("/change-phone-number", "Enter your new mobile phone number");
+    ENTER_NEW_MOBILE_PHONE_NUMBER("/change-phone-number", "Enter your new mobile phone number"),
+    GOV_UK_ACCOUNTS_COOKIES("/cookies", "GOV.UK accounts cookies policy");
 
     private static final String PRODUCT_NAME = "GOV.UK account";
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -21,9 +21,10 @@ import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_NEW_MOBILE_PHO
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_CHANGE_PASSWORD;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_DELETE_ACCOUNT;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_DELETE_ACCOUNT_FAILED;
+import static uk.gov.di.test.acceptance.AccountJourneyPages.GOV_UK_ACCOUNTS_COOKIES;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.PASSWORD_UPDATED_CONFIRMATION;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.YOUR_GOV_UK_ACCOUNT;
-import static uk.gov.di.test.acceptance.SupportingPages.GOV_UK_ACCOUNTS_COOKIES;
+
 
 public class AccountManagementStepDefinitions extends SignInStepDefinitions {
 
@@ -207,9 +208,8 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
         saveCookieSettingsButton.click();
     }
 
-    @Then(
-            "the existing account management user is taken to the GOV.UK accounts cookies policy page")
+    @Then("the existing account management user is taken to the GOV.UK accounts cookies policy page")
     public void theExistingAccountManagementUserIsTakenToTheGOVUKAccountsCookiesPolicyPage() {
-        waitForPageLoad(String.valueOf(GOV_UK_ACCOUNTS_COOKIES));
+        waitForPageLoadThenValidate(GOV_UK_ACCOUNTS_COOKIES);
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -23,6 +23,7 @@ import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_DELET
 import static uk.gov.di.test.acceptance.AccountJourneyPages.ENTER_PASSWORD_DELETE_ACCOUNT_FAILED;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.PASSWORD_UPDATED_CONFIRMATION;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.YOUR_GOV_UK_ACCOUNT;
+import static uk.gov.di.test.acceptance.SupportingPages.GOV_UK_ACCOUNTS_COOKIES;
 
 public class AccountManagementStepDefinitions extends SignInStepDefinitions {
 
@@ -204,5 +205,11 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
         rejectCookiePolicyTickbox.click();
         WebElement saveCookieSettingsButton = driver.findElement(By.id("save-cookie-settings"));
         saveCookieSettingsButton.click();
+    }
+
+    @Then(
+            "the existing account management user is taken to the GOV.UK accounts cookies policy page")
+    public void theExistingAccountManagementUserIsTakenToTheGOVUKAccountsCookiesPolicyPage() {
+        waitForPageLoad(String.valueOf(GOV_UK_ACCOUNTS_COOKIES));
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -183,4 +183,26 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
     public void theExistingAccountManagementUserIsAskedToEnterTheirPasswordAgain() {
         waitForPageLoadThenValidate(ENTER_PASSWORD_DELETE_ACCOUNT_FAILED);
     }
+
+    @And("the existing account management user accepts the cookie policy")
+    public void theExistingAccountManagementUserAcceptsTheCookiePolicy() {
+        WebElement acceptCookiePolicyTickbox = driver.findElement(By.id("policy-cookies-accepted"));
+        acceptCookiePolicyTickbox.click();
+        WebElement saveCookieSettingsButton = driver.findElement(By.id("save-cookie-settings"));
+        saveCookieSettingsButton.click();
+    }
+
+    @And("the existing account management user clicks the go back link")
+    public void theExistingAccountManagementUserClicksTheGoBackLink() {
+        WebElement goBackLink = driver.findElement(By.id("go-back-link"));
+        goBackLink.click();
+    }
+
+    @And("the existing account management user rejects the cookie policy")
+    public void theExistingAccountManagementUserRejectsTheCookiePolicy() {
+        WebElement rejectCookiePolicyTickbox = driver.findElement(By.id("policy-cookies-rejected"));
+        rejectCookiePolicyTickbox.click();
+        WebElement saveCookieSettingsButton = driver.findElement(By.id("save-cookie-settings"));
+        saveCookieSettingsButton.click();
+    }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -353,8 +353,7 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
 
     @When("the user clicks the delete your GOV.UK account button")
     public void theUserClicksTheDeleteYourGOVUKAccountButton() {
-        WebElement deleteAccountButton =
-                driver.findElement(By.cssSelector("#main-content > div > div > form > button"));
+        WebElement deleteAccountButton = driver.findElement(By.className("govuk-button--warning"));
         deleteAccountButton.click();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -350,4 +350,11 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         radioShareInfoReject.click();
         findAndClickContinue();
     }
+
+    @When("the user clicks the delete your GOV.UK account button")
+    public void theUserClicksTheDeleteYourGOVUKAccountButton() {
+        WebElement deleteAccountButton =
+                driver.findElement(By.cssSelector("#main-content > div > div > form > button"));
+        deleteAccountButton.click();
+    }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -75,8 +75,7 @@ Feature: Login Journey
     And the existing account management user accepts the cookie policy
     And the existing account management user clicks the go back link
     Then the existing account management user is taken to the GOV.UK accounts cookies policy page
-    When the existing account management user clicks link by href "https://signin.build.account.gov.uk/cookies"
-    And the existing account management user rejects the cookie policy
+    When the existing account management user rejects the cookie policy
     And the existing account management user clicks the go back link
     Then the existing account management user is taken to the GOV.UK accounts cookies policy page
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -64,6 +64,22 @@ Feature: Login Journey
     When the existing account management user clicks link by href "/manage-your-account"
     Then the existing account management user is taken to the your gov uk account page
 
+  Scenario: Existing user updates their cookie preferences
+    Given the account management services are running
+    And the existing account management user has valid credentials
+    When the existing account management user navigates to account management
+    Then the existing account management user is taken to the your gov uk account page
+    When the existing account management user clicks link by href "/enter-password?type=changePhoneNumber"
+    Then the existing account management user is asked to enter their password
+    When the existing account management user clicks link by href "https://signin.build.account.gov.uk/cookies"
+    And the existing account management user accepts the cookie policy
+    And the existing account management user clicks the go back link
+    Then the existing account management user is asked to enter their password
+    When the existing account management user clicks link by href "https://signin.build.account.gov.uk/cookies"
+    And the existing account management user rejects the cookie policy
+    And the existing account management user clicks the go back link
+    Then the existing account management user is asked to enter their password
+
   Scenario: User changes their password
       Given the account management services are running
       And the existing account management user has valid credentials

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -74,11 +74,11 @@ Feature: Login Journey
     When the existing account management user clicks link by href "https://signin.build.account.gov.uk/cookies"
     And the existing account management user accepts the cookie policy
     And the existing account management user clicks the go back link
-    Then the existing account management user is asked to enter their password
+    Then the existing account management user is taken to the GOV.UK accounts cookies policy page
     When the existing account management user clicks link by href "https://signin.build.account.gov.uk/cookies"
     And the existing account management user rejects the cookie policy
     And the existing account management user clicks the go back link
-    Then the existing account management user is asked to enter their password
+    Then the existing account management user is taken to the GOV.UK accounts cookies policy page
 
   Scenario: User changes their password
       Given the account management services are running
@@ -116,7 +116,7 @@ Feature: Login Journey
       When the existing account management user uses their updated password
       And the existing account management user enters their updated password to delete account
       Then the existing account management user is taken to the delete account page
-      When the user clicks button by text Delete your GOV.UK account
+      When the user clicks the delete your GOV.UK account button
       Then the existing account management user is taken to the account deleted confirmation page
       When the not logged in user navigates to account root
       Then the not logged in user is taken to the Identity Provider Login Page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
@@ -38,4 +38,4 @@ Feature: Incomplete registration
     When the new user clicks link by href "https://build.account.gov.uk"
     When the new user clicks link by href "/enter-password?type=deleteAccount"
     When the new user enters their password
-    When the user clicks button by text Delete your GOV.UK account
+    When the user clicks the delete your GOV.UK account button


### PR DESCRIPTION
## What?

Addition of feature to encapsulate scenarios where an existing account management user changes their cookie policy and navigates back using the go back link. 
Also, removal of old step where an account deletion was submitted using text, replaced by targeting element by CSS for robustness.

## Why?

Coverage increase, identified as valuable.

