### PR TITLE
AUT-612: downgradle gradle to 7.4.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What?

Downgradle gradle to 7.4.1.

## Why?

The 7.5 Gradle image appears to have an issue.

## Related PRs

#117 
https://github.com/alphagov/di-infrastructure/pull/333