### PR TITLE
AUT-612: Additional test steps to support auth apps screens

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -25,7 +25,6 @@ import static uk.gov.di.test.acceptance.AccountJourneyPages.GOV_UK_ACCOUNTS_COOK
 import static uk.gov.di.test.acceptance.AccountJourneyPages.PASSWORD_UPDATED_CONFIRMATION;
 import static uk.gov.di.test.acceptance.AccountJourneyPages.YOUR_GOV_UK_ACCOUNT;
 
-
 public class AccountManagementStepDefinitions extends SignInStepDefinitions {
 
     private String emailAddress;

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -7,13 +7,15 @@ public enum AuthenticationJourneyPages {
     ACCOUNT_NOT_FOUND("/account-not-found", "No GOV.UK account found"),
     CHECK_YOUR_EMAIL("/check-your-email", "Check your email"),
     CREATE_PASSWORD("/create-password", "Create your password"),
+    GET_SECURITY_CODES("/get-security-codes", "Choose how to get security codes"),
+    FINISH_CREATING_YOUR_ACCOUNT_GET_SECURITY_CODES("/get-security-codes", "Finish creating your account"),
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
     ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
-    ENTER_EMAIL_EXISTING_USER("/enter-email", "Sign in to your GOV.UK account"),
+    ENTER_EMAIL_EXISTING_USER("/enter-email", "Enter your email address to sign in to your GOV.UK account"),
     SHARE_INFO("/share-info", "Share information from your GOV.UK account"),
     SECURITY_CODE_INVALID(
             "/security-code-invalid", "You entered the wrong security code too many times");

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -188,6 +188,24 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         findAndClickContinue();
     }
 
+    @Then("the new user is taken to the get security codes page")
+    public void theNewUserIsTakenToTheGetSecurityCodesPage() {
+        waitForPageLoadThenValidate(GET_SECURITY_CODES);
+    }
+
+    @Then("the new user is taken to the finish creating your account get security codes page")
+    public void theNewUserIsTakenToTheFinishCreatingYourAccountGetSecurityCodesPage() {
+        waitForPageLoadThenValidate(FINISH_CREATING_YOUR_ACCOUNT_GET_SECURITY_CODES);
+    }
+
+    @When("the new user chooses text message security codes")
+    public void theNewUserChoosesTextMessageSecurityCodes() {
+        WebElement radioTextMessageSecurityCodes =
+                driver.findElement(By.id("mfa-options-text-message"));
+        radioTextMessageSecurityCodes.click();
+        findAndClickContinue();
+    }
+
     @Then("the new user is taken to the enter phone number page")
     public void theNewUserIsTakenToTheEnterPhoneNumberPage() {
         waitForPageLoadThenValidate(ENTER_PHONE_NUMBER);

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_registration_journey.feature
@@ -64,6 +64,8 @@ Feature: Registration Journey
     Then the new user is taken to the create your password page
     When the new user creates a password
     And there are no accessibility violations
+    Then the new user is taken to the get security codes page
+    When the new user chooses text message security codes
     Then the new user is taken to the enter phone number page
     When the new user enters their mobile phone number
     Then the new user is taken to the check your phone page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
@@ -15,6 +15,8 @@ Feature: Incomplete registration
     When the new user enters the six digit security code from their email
     Then the new user is taken to the create your password page
     When the new user creates a password
+    Then the new user is taken to the get security codes page
+    When the new user chooses text message security codes
     Then the new user is taken to the enter phone number page
     When the new user enters their mobile phone number
     Then the new user is taken to the check your phone page
@@ -26,7 +28,9 @@ Feature: Incomplete registration
     When the new user selects sign in
     When the new user enters their email address
     When the new user enters their password
-    Then the new user is taken to the finish creating your account page
+    Then the new user is taken to the finish creating your account get security codes page
+    When the new user chooses text message security codes
+    Then the new user is taken to the enter phone number page
     When the new user enters their mobile phone number
     Then the new user is taken to the check your phone page
     When the new user enters the six digit security code from their phone

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
@@ -44,6 +44,8 @@ Feature: Locked accounts
     When the new user enters the six digit security code from their email
     Then the new user is taken to the create your password page
     When the new user creates a password
+    Then the new user is taken to the get security codes page
+    When the new user chooses text message security codes
     Then the new user is taken to the enter phone number page
     When the new user enters their mobile phone number
     Then the new user is taken to the check your phone page
@@ -57,5 +59,8 @@ Feature: Locked accounts
     Then the new user is taken to the sign in to your account page
     When the new user enters their email address
     When the new user enters their password
+    Then the new user is taken to the finish creating your account get security codes page
+    When the new user chooses text message security codes
+    Then the new user is taken to the enter phone number page
     When the new user enters their mobile phone number
     Then the new user is taken to the security code invalid page


### PR DESCRIPTION

## What?

Additional test steps to support auth apps screens

When authenticator apps are switched on then the 'get security codes' screen appears before 'enter phone number' when creating an account.  This initial step just chooses 'text message' then continues the scenarios as before.

## Why?

Add the bare minimum amount of test steps to enable auth apps to be switched on in build, and for the acceptance tests to succeed.