### PR TITLE
AUT-613: Initial additional scenario for auth apps

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -22,7 +22,8 @@ dependencies {
     testImplementation "io.cucumber:cucumber-java:${dependencyVersions.cucumber_version}",
                        "io.cucumber:cucumber-junit:${dependencyVersions.cucumber_version}",
                        "org.seleniumhq.selenium:selenium-java:4.3.0",
-                       "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}"
+                       "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
+                       "commons-codec:commons-codec:1.15"
 
     testImplementation group: 'com.deque', name: 'axe-selenium', version:"${dependencyVersions.axe_version}"
     testImplementation group: 'org.json', name: 'json', version:"${dependencyVersions.json_version}"

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AccountManagementStepDefinitions.java
@@ -207,7 +207,8 @@ public class AccountManagementStepDefinitions extends SignInStepDefinitions {
         saveCookieSettingsButton.click();
     }
 
-    @Then("the existing account management user is taken to the GOV.UK accounts cookies policy page")
+    @Then(
+            "the existing account management user is taken to the GOV.UK accounts cookies policy page")
     public void theExistingAccountManagementUserIsTakenToTheGOVUKAccountsCookiesPolicyPage() {
         waitForPageLoadThenValidate(GOV_UK_ACCOUNTS_COOKIES);
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -8,14 +8,20 @@ public enum AuthenticationJourneyPages {
     CHECK_YOUR_EMAIL("/check-your-email", "Check your email"),
     CREATE_PASSWORD("/create-password", "Create your password"),
     GET_SECURITY_CODES("/get-security-codes", "Choose how to get security codes"),
-    FINISH_CREATING_YOUR_ACCOUNT_GET_SECURITY_CODES("/get-security-codes", "Finish creating your account"),
+    FINISH_CREATING_YOUR_ACCOUNT_GET_SECURITY_CODES(
+            "/get-security-codes", "Finish creating your account"),
+    SETUP_AUTHENTICATOR_APP("/setup-authenticator-app", "Set up an authenticator app"),
+    ENTER_AUTHENTICATOR_APP_CODE(
+            "/enter-authenticator-app-code",
+            "Enter the 6 digit security code shown in your authenticator app"),
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
     ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
-    ENTER_EMAIL_EXISTING_USER("/enter-email", "Enter your email address to sign in to your GOV.UK account"),
+    ENTER_EMAIL_EXISTING_USER(
+            "/enter-email", "Enter your email address to sign in to your GOV.UK account"),
     SHARE_INFO("/share-info", "Share information from your GOV.UK account"),
     SECURITY_CODE_INVALID(
             "/security-code-invalid", "You entered the wrong security code too many times");

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import uk.gov.di.test.utils.AuthAppStub;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -29,6 +30,7 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
     private String sixDigitCodePhone;
     private String tcEmailAddress;
     private String tcPassword;
+    private String authAppSecretKey;
 
     @Before
     public void setupWebdriver() throws MalformedURLException {
@@ -73,6 +75,13 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         sixDigitCodePhone = System.getenv().get("TEST_USER_PHONE_CODE");
         tcEmailAddress = System.getenv().get("TERMS_AND_CONDITIONS_TEST_USER_EMAIL");
         tcPassword = System.getenv().get("TERMS_AND_CONDITIONS_TEST_USER_PASSWORD");
+    }
+
+    @And("the auth app user has valid credentials")
+    public void theAuthAppUserHasValidCredentials() {
+        emailAddress = System.getenv().get("TEST_USER_AUTH_APP_EMAIL");
+        password = System.getenv().get("TEST_USER_PASSWORD");
+        sixDigitCodeEmail = System.getenv().get("TEST_USER_EMAIL_CODE");
     }
 
     @And("the new user clears cookies")
@@ -206,6 +215,67 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         findAndClickContinue();
     }
 
+    @When("the new user chooses {string} to get security codes")
+    public void theNewUserChoosesHowToGetSecurityCodes(String mfaMethod) {
+        WebElement radioTextMessageSecurityCodes = driver.findElement(By.id(mfaMethod));
+        radioTextMessageSecurityCodes.click();
+        findAndClickContinue();
+    }
+
+    @Then("the new user is taken to the setup authenticator app page")
+    public void theNewUserIsTakenToTheSetupAuthenticatorAppPage() {
+        waitForPageLoadThenValidate(SETUP_AUTHENTICATOR_APP);
+    }
+
+    @When("the new user adds the secret key on the screen to their auth app")
+    public void theNewUserAddTheSecretKeyOnTheScreenToTheirAuthApp() {
+        WebElement secretKeyField = driver.findElement(By.id("secret-key"));
+        authAppSecretKey = secretKeyField.getText().trim();
+    }
+
+    @And("the user enters the security code from the auth app")
+    public void theNewUserEntersTheSecurityCodeFromTheAuthApp() {
+        WebElement securityCodeField = driver.findElement(By.id("code"));
+        AuthAppStub authAppStub = new AuthAppStub();
+        securityCodeField.sendKeys(authAppStub.getAuthAppOneTimeCode(authAppSecretKey));
+        findAndClickContinue();
+    }
+
+    @When("the existing auth app user selects sign in")
+    public void theExistingAuthAppUserSelectsSignIn() {
+        WebElement link = driver.findElement(By.id("sign-in-link"));
+        link.click();
+    }
+
+    @Then("the existing auth app user is taken to the enter your email page")
+    public void theExistingAuthAppUserIsTakenToTheEnterYourEmailPage() {
+        waitForPageLoadThenValidate(ENTER_EMAIL_EXISTING_USER);
+    }
+
+    @When("the existing auth app user enters their email address")
+    public void theExistingAuthAppUserEntersEmailAddress() {
+        WebElement emailAddressField = driver.findElement(By.id("email"));
+        emailAddressField.sendKeys(emailAddress);
+        findAndClickContinue();
+    }
+
+    @Then("the existing auth app user is prompted for their password")
+    public void theExistingUserIsPromptedForPassword() {
+        waitForPageLoadThenValidate(ENTER_PASSWORD);
+    }
+
+    @When("the existing auth app user enters their password")
+    public void theExistingUserEntersTheirPassword() {
+        WebElement passwordField = driver.findElement(By.id("password"));
+        passwordField.sendKeys(password);
+        findAndClickContinue();
+    }
+
+    @Then("the existing user is taken to the enter authenticator app code page")
+    public void theNewUserIsTakenToTheEnterAuthenticatorAppCodePage() {
+        waitForPageLoadThenValidate(ENTER_AUTHENTICATOR_APP_CODE);
+    }
+
     @Then("the new user is taken to the enter phone number page")
     public void theNewUserIsTakenToTheEnterPhoneNumberPage() {
         waitForPageLoadThenValidate(ENTER_PHONE_NUMBER);
@@ -267,8 +337,8 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         findAndClickContinue();
     }
 
-    @Then("the new user is returned to the service")
-    public void theNewUserIsReturnedToTheService() {}
+    @Then("the user is returned to the service")
+    public void theUserIsReturnedToTheService() {}
 
     @Then("the new user is taken to the Service User Info page")
     public void theNewUserIsTakenToTheServiceUserInfoPage() {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthAppStub.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthAppStub.java
@@ -1,0 +1,65 @@
+package uk.gov.di.test.utils;
+
+import org.apache.commons.codec.binary.Base32;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.util.concurrent.TimeUnit;
+
+public class AuthAppStub {
+    private static final int CODE_DIGITS = 6;
+    private static final long TIME_WINDOW_IN_MILLISECONDS = TimeUnit.SECONDS.toMillis(30);
+
+    public String getAuthAppOneTimeCode(String secret) {
+        return getAuthAppOneTimeCode(secret, NowHelper.now().getTime());
+    }
+
+    public String getAuthAppOneTimeCode(String secret, long time) {
+        int codeAsInt = getCodeAsInt(decodeBase32Secret(secret), getTimeWindowFromTime(time));
+        return Integer.toString(codeAsInt);
+    }
+
+    int getCodeAsInt(byte[] secret, long time) {
+        byte[] data = new byte[8];
+
+        for (int i = 8; i-- > 0; time >>>= 8) {
+            data[i] = (byte) time;
+        }
+
+        SecretKeySpec signKey = new SecretKeySpec(secret, "HmacSHA1");
+
+        try {
+            Mac mac = Mac.getInstance("HmacSHA1");
+
+            mac.init(signKey);
+
+            byte[] hash = mac.doFinal(data);
+
+            int offset = hash[hash.length - 1] & 0xF;
+
+            long truncatedHash = 0;
+
+            for (int i = 0; i < 4; ++i) {
+                truncatedHash <<= 8;
+                truncatedHash |= (hash[offset + i] & 0xFF);
+            }
+
+            truncatedHash &= 0x7FFFFFFF;
+            truncatedHash %= (int) Math.pow(10, CODE_DIGITS);
+
+            return (int) truncatedHash;
+        } catch (Exception ex) {
+            return 0;
+        }
+    }
+
+    public byte[] decodeBase32Secret(String secret) {
+        Base32 codec32 = new Base32();
+        return codec32.decode(secret);
+    }
+
+    private long getTimeWindowFromTime(long time) {
+        return time / TIME_WINDOW_IN_MILLISECONDS;
+    }
+}

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/NowHelper.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/NowHelper.java
@@ -1,0 +1,47 @@
+package uk.gov.di.test.utils;
+
+import java.text.SimpleDateFormat;
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+public class NowHelper {
+
+    private static final NowClock clock = new NowClock(Clock.systemUTC());
+
+    public static Date now() {
+        return clock.now();
+    }
+
+    public static Date nowPlus(long amount, ChronoUnit unit) {
+        return clock.nowPlus(amount, unit);
+    }
+
+    public static Date nowMinus(long amount, ChronoUnit unit) {
+        return clock.nowMinus(amount, unit);
+    }
+
+    public static String toTimestampString(Date date) {
+        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS").format(date);
+    }
+
+    public static class NowClock {
+        private final Clock clock;
+
+        public NowClock(Clock clock) {
+            this.clock = clock;
+        }
+
+        public Date now() {
+            return Date.from(clock.instant());
+        }
+
+        public Date nowPlus(long amount, ChronoUnit unit) {
+            return Date.from(clock.instant().plus(amount, unit));
+        }
+
+        public Date nowMinus(long amount, ChronoUnit unit) {
+            return Date.from(clock.instant().minus(amount, unit));
+        }
+    }
+}

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/003_legal_and_policy_pages.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/003_legal_and_policy_pages.feature
@@ -35,7 +35,7 @@ Feature: Legal and policy pages
     When the new user clicks link by href "/updated-terms-and-conditions-disagree"
     Then the new user is taken to the Agree to the updated terms of use to continue page
     When the new user clicks by name "termsAndConditionsResult"
-    Then the new user is returned to the service
+    Then the user is returned to the service
     When the new user clicks by name "logout"
     And there are no accessibility violations
     Then the new user is taken to the signed out page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
@@ -1,0 +1,50 @@
+Feature: Authentication App Journeys
+  New user creates an account and logs in using an auth app
+
+  @AuthApp2FA
+  Scenario: User successfully registers with auth app 2FA, logs out then signs in again
+    Given the registration services are running
+    And the auth app user has valid credentials
+    And the new user clears cookies
+    When the new user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the new user selects create an account
+    And there are no accessibility violations
+    Then the new user is taken to the enter your email page
+    When the new user enters their email address
+    Then the new user is asked to check their email
+    When the new user enters the six digit security code from their email
+    And there are no accessibility violations
+    Then the new user is taken to the create your password page
+    When the new user creates a password
+    And there are no accessibility violations
+    Then the new user is taken to the get security codes page
+    When the new user chooses "mfa-options-auth-app" to get security codes
+    Then the new user is taken to the setup authenticator app page
+    When the new user adds the secret key on the screen to their auth app
+    And the user enters the security code from the auth app
+    And there are no accessibility violations
+    Then the new user is taken to the account created page
+    When the new user clicks the continue button
+    And there are no accessibility violations
+    Then the new user is taken the the share info page
+    When the new user agrees to share their info
+    Then the user is returned to the service
+    When the new user clicks by name "logout"
+    And there are no accessibility violations
+    Then the new user is taken to the signed out page
+    When the user visits the stub relying party
+    And the new user clicks "govuk-signin-button"
+    Then the new user is taken to the Identity Provider Login Page
+    When the existing auth app user selects sign in
+    Then the existing auth app user is taken to the enter your email page
+    When the existing auth app user enters their email address
+    Then the existing auth app user is prompted for their password
+    When the existing auth app user enters their password
+    Then the existing user is taken to the enter authenticator app code page
+    When the user enters the security code from the auth app
+    Then the user is returned to the service
+    When the new user clicks by name "logout"
+    And there are no accessibility violations
+    Then the new user is taken to the signed out page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/006_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/006_registration_journey.feature
@@ -5,7 +5,7 @@ Feature: Registration Journey
     Given the registration services are running
     And a new user has valid credentials
     And the new user clears cookies
-    When the new user visits the stub relying party
+    When the user visits the stub relying party
     And the new user clicks "govuk-signin-button"
     Then the new user is taken to the Identity Provider Login Page
     When the new user selects sign in
@@ -20,7 +20,7 @@ Feature: Registration Journey
     Given the registration services are running
     And the new user has an invalid email format
     And the new user clears cookies
-    When the new user visits the stub relying party
+    When the user visits the stub relying party
     And the new user clicks "govuk-signin-button"
     Then the new user is taken to the Identity Provider Login Page
     When the new user selects create an account
@@ -51,7 +51,7 @@ Feature: Registration Journey
     Given the registration services are running
     And a new user has valid credentials
     And the new user clears cookies
-    When the new user visits the stub relying party
+    When the user visits the stub relying party
     And the new user clicks "govuk-signin-button"
     Then the new user is taken to the Identity Provider Login Page
     When the new user selects create an account
@@ -76,7 +76,7 @@ Feature: Registration Journey
     And there are no accessibility violations
     Then the new user is taken the the share info page
     When the new user agrees to share their info
-    Then the new user is returned to the service
+    Then the user is returned to the service
     When the new user clicks by name "logout"
     And there are no accessibility violations
     Then the new user is taken to the signed out page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
@@ -38,7 +38,7 @@ Feature: Incomplete registration
     When the new user clicks the continue button
     Then the new user is taken the the share info page
     When the new user does not agree to share their info
-    Then the new user is returned to the service
+    Then the user is returned to the service
     When the new user clicks link by href "https://build.account.gov.uk"
     When the new user clicks link by href "/enter-password?type=deleteAccount"
     When the new user enters their password


### PR DESCRIPTION
## What?

Initial additional scenario for auth apps.

## Why?

Creates an account with an auth app, logs out, then logs back in again.
Doing all this in a single scenario means there is no need to persist a secret for the auth app (for now, this can be added later as an additional scenario).

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/337