### PR TITLE
BAU: Consent to share off in the acceptance tests

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
@@ -28,8 +28,6 @@ Feature: Authentication App Journeys
     Then the new user is taken to the account created page
     When the new user clicks the continue button
     And there are no accessibility violations
-    Then the new user is taken the the share info page
-    When the new user agrees to share their info
     Then the user is returned to the service
     When the new user clicks by name "logout"
     And there are no accessibility violations

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/006_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/006_registration_journey.feature
@@ -74,8 +74,6 @@ Feature: Registration Journey
     Then the new user is taken to the account created page
     When the new user clicks the continue button
     And there are no accessibility violations
-    Then the new user is taken the the share info page
-    When the new user agrees to share their info
     Then the user is returned to the service
     When the new user clicks by name "logout"
     And there are no accessibility violations

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/015_incomplete_registration.feature
@@ -36,8 +36,6 @@ Feature: Incomplete registration
     When the new user enters the six digit security code from their phone
     Then the new user is taken to the account created page
     When the new user clicks the continue button
-    Then the new user is taken the the share info page
-    When the new user does not agree to share their info
     Then the user is returned to the service
     When the new user clicks link by href "https://build.account.gov.uk"
     When the new user clicks link by href "/enter-password?type=deleteAccount"


### PR DESCRIPTION
## What?

Consent to share off in the acceptance tests.

## Why?

Consent to share is still switched-on in the acceptance test client because there were existing tests that had been built to use it while it was still required.  The decision has been made the consent will be off for all clients so it makes more sense to remove these steps from the tests in order to reflect what is live.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2215