### PR TITLE
BAU: Format the auth app security code using 6 digits and leading zeros

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthAppStub.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthAppStub.java
@@ -17,7 +17,7 @@ public class AuthAppStub {
 
     public String getAuthAppOneTimeCode(String secret, long time) {
         int codeAsInt = getCodeAsInt(decodeBase32Secret(secret), getTimeWindowFromTime(time));
-        return Integer.toString(codeAsInt);
+        return String.format("%06d", codeAsInt);
     }
 
     int getCodeAsInt(byte[] secret, long time) {


### PR DESCRIPTION
## What?

Format the auth app security code using 6 digits and leading zeros.
A change to the auth app stub.

## Why?

Leading zeros were being removed when converting the code from int to String.