### PR TITLE
Aut 694 acceptance tests welsh content switch

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -22,7 +22,9 @@ public enum AuthenticationJourneyPages {
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
     ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
+    ENTER_PASSWORD_WELSH("/enter-password", "Rhowch eich cyfrinair"),
     ENTER_CODE("/enter-code", "Check your phone"),
+    ENTER_CODE_WELSH("/enter-code", "Gwiriwch eich ffôn"),
     ENTER_EMAIL_EXISTING_USER(
             "/enter-email", "Enter your email address to sign in to your GOV.UK account"),
     ENTER_EMAIL_EXISTING_USER_WELSH("/enter-email", "Rhowch eich cyfeiriad e-bost i fewngofnodi i'ch cyfrif GOV.UK"),

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -2,6 +2,7 @@ package uk.gov.di.test.acceptance;
 
 public enum AuthenticationJourneyPages {
     SIGN_IN_OR_CREATE("/sign-in-or-create", "Create a GOV.UK account or sign in"),
+    SIGN_IN_OR_CREATE_WELSH("/sign-in-or-create", "Creu cyfrif GOV.UK neu fewngofnodi"),
     ENTER_EMAIL("/enter-email", "Enter your email address"),
     ENTER_EMAIL_CREATE("/enter-email-create", "Enter your email address"),
     ACCOUNT_NOT_FOUND("/account-not-found", "No GOV.UK account found"),
@@ -24,6 +25,7 @@ public enum AuthenticationJourneyPages {
     ENTER_CODE("/enter-code", "Check your phone"),
     ENTER_EMAIL_EXISTING_USER(
             "/enter-email", "Enter your email address to sign in to your GOV.UK account"),
+    ENTER_EMAIL_EXISTING_USER_WELSH("/enter-email", "Rhowch eich cyfeiriad e-bost i fewngofnodi i'ch cyfrif GOV.UK"),
     SHARE_INFO("/share-info", "Share information from your GOV.UK account"),
     SECURITY_CODE_INVALID(
             "/security-code-invalid", "You entered the wrong security code too many times"),

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -27,7 +27,8 @@ public enum AuthenticationJourneyPages {
     ENTER_CODE_WELSH("/enter-code", "Gwiriwch eich ffôn"),
     ENTER_EMAIL_EXISTING_USER(
             "/enter-email", "Enter your email address to sign in to your GOV.UK account"),
-    ENTER_EMAIL_EXISTING_USER_WELSH("/enter-email", "Rhowch eich cyfeiriad e-bost i fewngofnodi i'ch cyfrif GOV.UK"),
+    ENTER_EMAIL_EXISTING_USER_WELSH(
+            "/enter-email", "Rhowch eich cyfeiriad e-bost i fewngofnodi i'ch cyfrif GOV.UK"),
     SHARE_INFO("/share-info", "Share information from your GOV.UK account"),
     SECURITY_CODE_INVALID(
             "/security-code-invalid", "You entered the wrong security code too many times"),

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -2,7 +2,6 @@ package uk.gov.di.test.acceptance;
 
 public enum AuthenticationJourneyPages {
     SIGN_IN_OR_CREATE("/sign-in-or-create", "Create a GOV.UK account or sign in"),
-    SIGN_IN_OR_CREATE_WELSH("/sign-in-or-create", "Creu cyfrif GOV.UK neu fewngofnodi"),
     ENTER_EMAIL("/enter-email", "Enter your email address"),
     ENTER_EMAIL_CREATE("/enter-email-create", "Enter your email address"),
     ACCOUNT_NOT_FOUND("/account-not-found", "No GOV.UK account found"),
@@ -22,13 +21,9 @@ public enum AuthenticationJourneyPages {
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
     ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
-    ENTER_PASSWORD_WELSH("/enter-password", "Rhowch eich cyfrinair"),
     ENTER_CODE("/enter-code", "Check your phone"),
-    ENTER_CODE_WELSH("/enter-code", "Gwiriwch eich ffôn"),
     ENTER_EMAIL_EXISTING_USER(
             "/enter-email", "Enter your email address to sign in to your GOV.UK account"),
-    ENTER_EMAIL_EXISTING_USER_WELSH(
-            "/enter-email", "Rhowch eich cyfeiriad e-bost i fewngofnodi i'ch cyfrif GOV.UK"),
     SHARE_INFO("/share-info", "Share information from your GOV.UK account"),
     SECURITY_CODE_INVALID(
             "/security-code-invalid", "You entered the wrong security code too many times"),

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -19,16 +19,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.CANNOT_GET_NEW_SECURITY_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_CODE;
-import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_CODE_WELSH;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER;
-import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER_WELSH;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PASSWORD;
-import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PASSWORD_WELSH;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PHONE_NUMBER;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.RESEND_SECURITY_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.RESEND_SECURITY_CODE_TOO_MANY_TIMES;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.SIGN_IN_OR_CREATE;
-import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.SIGN_IN_OR_CREATE_WELSH;
 
 public class LoginStepDefinitions extends SignInStepDefinitions {
 
@@ -201,12 +197,12 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
 
     @Then("the existing user is taken to the Identity Provider Welsh Login Page")
     public void theExistingUserIsTakenToTheIdentityProviderWelshLoginPage() {
-        waitForPageLoadThenValidate(SIGN_IN_OR_CREATE_WELSH);
+        assertEquals("Creu cyfrif GOV.UK neu fewngofnodi - Cyfrif GOV.UK", driver.getTitle());
     }
 
     @Then("the existing user is taken to the Welsh enter your email page")
     public void theExistingUserIsTakenToTheWelshEnterYourEmailPage() {
-        waitForPageLoadThenValidate(ENTER_EMAIL_EXISTING_USER_WELSH);
+        assertEquals("Rhowch eich cyfeiriad e-bost i fewngofnodi i'ch cyfrif GOV.UK - Cyfrif GOV.UK", driver.getTitle());
         WebElement continueButton =
                 driver.findElement(By.cssSelector("#main-content > div > div > form > button"));
         // Assertions.assertNotEquals("Continue", continueButton.getText());
@@ -216,11 +212,25 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
 
     @Then("the existing user is prompted for their password in Welsh")
     public void theExistingUserIsPromptedForTheirPasswordInWelsh() {
-        waitForPageLoadThenValidate(ENTER_PASSWORD_WELSH);
+        assertEquals("Rhowch eich cyfrinair - Cyfrif GOV.UK", driver.getTitle());
     }
 
     @Then("the existing user is taken to the Welsh enter code page")
     public void theExistingUserIsTakenToTheWelshEnterCodePage() {
-        waitForPageLoadThenValidate(ENTER_CODE_WELSH);
+        assertEquals("Gwiriwch eich ffôn - Cyfrif GOV.UK", driver.getTitle());
+    }
+
+    @When("the existing user enters their password in Welsh")
+    public void theExistingUserEntersTheirPasswordInWelsh() {
+        WebElement passwordField = driver.findElement(By.id("password"));
+        passwordField.sendKeys(password);
+        findAndClickContinueWelsh();
+    }
+
+    @When("the existing user enters their email address in Welsh")
+    public void theExistingUserEntersTheirEmailAddressInWelsh() {
+        WebElement emailAddressField = driver.findElement(By.id("email"));
+        emailAddressField.sendKeys(emailAddress);
+        findAndClickContinueWelsh();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -210,7 +210,9 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
         waitForPageLoadThenValidate(ENTER_EMAIL_EXISTING_USER_WELSH);
         WebElement continueButton = driver.findElement(
                         By.cssSelector("#main-content > div > div > form > button"));
-        Assertions.assertEquals("Parhau", continueButton.getText());
+        //Assertions.assertNotEquals("Continue", continueButton.getText());
+        WebElement backButton = driver.findElement(By.className(("govuk-back-link")));
+        //Assertions.assertNotEquals("Back", backButton.getText());
     }
 
     @Then("the existing user is prompted for their password in Welsh")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -5,6 +5,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.junit.jupiter.api.Assertions;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -19,9 +20,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.CANNOT_GET_NEW_SECURITY_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_CODE;
+import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_CODE_WELSH;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER_WELSH;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PASSWORD;
+import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PASSWORD_WELSH;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PHONE_NUMBER;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.RESEND_SECURITY_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.RESEND_SECURITY_CODE_TOO_MANY_TIMES;
@@ -205,5 +208,18 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
     @Then("the existing user is taken to the Welsh enter your email page")
     public void theExistingUserIsTakenToTheWelshEnterYourEmailPage() {
         waitForPageLoadThenValidate(ENTER_EMAIL_EXISTING_USER_WELSH);
+        WebElement continueButton = driver.findElement(
+                        By.cssSelector("#main-content > div > div > form > button"));
+        Assertions.assertEquals("Parhau", continueButton.getText());
+    }
+
+    @Then("the existing user is prompted for their password in Welsh")
+    public void theExistingUserIsPromptedForTheirPasswordInWelsh() {
+        waitForPageLoadThenValidate(ENTER_PASSWORD_WELSH);
+    }
+
+    @Then("the existing user is taken to the Welsh enter code page")
+    public void theExistingUserIsTakenToTheWelshEnterCodePage() {
+        waitForPageLoadThenValidate(ENTER_CODE_WELSH);
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -5,7 +5,6 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.junit.jupiter.api.Assertions;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -208,11 +207,11 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
     @Then("the existing user is taken to the Welsh enter your email page")
     public void theExistingUserIsTakenToTheWelshEnterYourEmailPage() {
         waitForPageLoadThenValidate(ENTER_EMAIL_EXISTING_USER_WELSH);
-        WebElement continueButton = driver.findElement(
-                        By.cssSelector("#main-content > div > div > form > button"));
-        //Assertions.assertNotEquals("Continue", continueButton.getText());
+        WebElement continueButton =
+                driver.findElement(By.cssSelector("#main-content > div > div > form > button"));
+        // Assertions.assertNotEquals("Continue", continueButton.getText());
         WebElement backButton = driver.findElement(By.className(("govuk-back-link")));
-        //Assertions.assertNotEquals("Back", backButton.getText());
+        // Assertions.assertNotEquals("Back", backButton.getText());
     }
 
     @Then("the existing user is prompted for their password in Welsh")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -20,11 +20,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.CANNOT_GET_NEW_SECURITY_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER;
+import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER_WELSH;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PASSWORD;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.ENTER_PHONE_NUMBER;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.RESEND_SECURITY_CODE;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.RESEND_SECURITY_CODE_TOO_MANY_TIMES;
 import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.SIGN_IN_OR_CREATE;
+import static uk.gov.di.test.acceptance.AuthenticationJourneyPages.SIGN_IN_OR_CREATE_WELSH;
 
 public class LoginStepDefinitions extends SignInStepDefinitions {
 
@@ -193,5 +195,15 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
     public void theExistingResendCodeUserHasValidCredentials() {
         emailAddress = System.getenv().get("RESEND_CODE_TEST_USER_EMAIL");
         password = System.getenv().get("TERMS_AND_CONDITIONS_TEST_USER_PASSWORD");
+    }
+
+    @Then("the existing user is taken to the Identity Provider Welsh Login Page")
+    public void theExistingUserIsTakenToTheIdentityProviderWelshLoginPage() {
+        waitForPageLoadThenValidate(SIGN_IN_OR_CREATE_WELSH);
+    }
+
+    @Then("the existing user is taken to the Welsh enter your email page")
+    public void theExistingUserIsTakenToTheWelshEnterYourEmailPage() {
+        waitForPageLoadThenValidate(ENTER_EMAIL_EXISTING_USER_WELSH);
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
@@ -90,6 +90,11 @@ public class SignInStepDefinitions {
         continueButton.click();
     }
 
+    protected void findAndClickContinueWelsh() {
+        WebElement continueButton = driver.findElement(By.cssSelector("#main-content > div > div > form > button"));
+        continueButton.click();
+    }
+
     protected void findAndClickButtonByText(String buttonText) {
         WebElement continueButton =
                 driver.findElement(

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -67,6 +67,19 @@ Feature: Login Journey
     When the existing user enters the six digit security code from their phone
     Then the existing user is returned to the service
 
+  Scenario: Existing user switches content to Welsh
+    Given the login services are running
+    And the existing user has valid credentials
+    When the existing user visits the stub relying party
+    And the existing user clicks "lng-cy"
+    And the existing user clicks "govuk-signin-button"
+    Then the existing user is taken to the Identity Provider Welsh Login Page
+    When the existing user selects sign in
+    Then the existing user is taken to the Welsh enter your email page
+    When the existing user enters their email address
+    Then the existing user is prompted for their password
+    When the existing user enters their password
+
   Scenario: Existing user attempts to change their phone number using their existing one
     Given the account management services are running
     And the existing account management user has valid credentials

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -80,6 +80,12 @@ Feature: Login Journey
     Then the existing user is prompted for their password in Welsh
     When the existing user enters their password
     Then the existing user is taken to the Welsh enter code page
+    When the existing user visits the stub relying party
+    And the existing user clicks "lng-cy"
+    And the existing user clicks "govuk-signin-button"
+    Then the existing user is taken to the Identity Provider Welsh Login Page
+    When the existing account management user selects create an account
+    Then the existing user is taken to the Welsh enter your email page
 
   Scenario: Existing user attempts to change their phone number using their existing one
     Given the account management services are running

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -77,8 +77,9 @@ Feature: Login Journey
     When the existing user selects sign in
     Then the existing user is taken to the Welsh enter your email page
     When the existing user enters their email address
-    Then the existing user is prompted for their password
+    Then the existing user is prompted for their password in Welsh
     When the existing user enters their password
+    Then the existing user is taken to the Welsh enter code page
 
   Scenario: Existing user attempts to change their phone number using their existing one
     Given the account management services are running

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -44,6 +44,19 @@ Feature: Login Journey
     And the existing user clicks by name "logout"
     Then the existing user is taken to the you have signed out page
 
+  Scenario: Existing user switches content to Welsh
+    Given the login services are running
+    And the existing user has valid credentials
+    When the existing account management user navigates to account management
+    And the existing account management user clicks link by href "?lng=cy"
+    Then the existing user is taken to the Identity Provider Welsh Login Page
+    When the existing user selects sign in
+    Then the existing user is taken to the Welsh enter your email page
+    When the existing user enters their email address in Welsh
+    Then the existing user is prompted for their password in Welsh
+    When the existing user enters their password in Welsh
+    Then the existing user is taken to the Welsh enter code page
+
   Scenario: Existing user logs in without 2FA
     Given the login services are running
     And the existing user has valid credentials
@@ -66,26 +79,6 @@ Feature: Login Journey
     Then the existing user is taken to the enter code page
     When the existing user enters the six digit security code from their phone
     Then the existing user is returned to the service
-
-  Scenario: Existing user switches content to Welsh
-    Given the login services are running
-    And the existing user has valid credentials
-    When the existing user visits the stub relying party
-    And the existing user clicks "lng-cy"
-    And the existing user clicks "govuk-signin-button"
-    Then the existing user is taken to the Identity Provider Welsh Login Page
-    When the existing user selects sign in
-    Then the existing user is taken to the Welsh enter your email page
-    When the existing user enters their email address
-    Then the existing user is prompted for their password in Welsh
-    When the existing user enters their password
-    Then the existing user is taken to the Welsh enter code page
-    When the existing user visits the stub relying party
-    And the existing user clicks "lng-cy"
-    And the existing user clicks "govuk-signin-button"
-    Then the existing user is taken to the Identity Provider Welsh Login Page
-    When the existing account management user selects create an account
-    Then the existing user is taken to the Welsh enter your email page
 
   Scenario: Existing user attempts to change their phone number using their existing one
     Given the account management services are running


### PR DESCRIPTION
## What?

Additional AC test scenario where an existing user switches content to Welsh. NOTE: some failures regarding to missing localisation on "Back" and "Continue" button are currently commented out and will be brought back in when the fix is in.

## Why?

To increase coverage.