### PR TITLE
AUT-691: Update Welsh test to switch back to English

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -54,8 +54,12 @@ Feature: Login Journey
     Then the existing user is taken to the Welsh enter your email page
     When the existing user enters their email address in Welsh
     Then the existing user is prompted for their password in Welsh
-    When the existing user enters their password in Welsh
-    Then the existing user is taken to the Welsh enter code page
+    When the user clicks link "Yn ôl"
+    Then the existing user is taken to the Welsh enter your email page
+    When the user clicks link "Yn ôl"
+    Then the existing user is taken to the Identity Provider Welsh Login Page
+    When the existing account management user clicks link by href "?lng=en"
+    Then the existing user is taken to the Identity Provider Login Page
 
   Scenario: Existing user logs in without 2FA
     Given the login services are running


### PR DESCRIPTION
## What?

Update Welsh test to switch back to English

## Why?

As the same session is being used in the following test Welsh language is maintained, whereas the tests are checking for English.  This change is needed to due the fix for AUT-691 which has made the language behaviour consistent across applications.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/765