### PR TITLE
Re-adding the cookie scenario

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/010_existing_user_journey.feature
@@ -98,21 +98,18 @@ Feature: Login Journey
     When the existing account management user clicks link by href "/manage-your-account"
     Then the existing account management user is taken to the your gov uk account page
 
-  #Scenario: Existing user updates their cookie preferences
-    #Given the account management services are running
-    #And the existing account management user has valid credentials
-    #When the existing account management user navigates to account management
-    #Then the existing account management user is taken to the your gov uk account page
-    #When the existing account management user clicks link by href "/enter-password?type=changePhoneNumber"
-    #Then the existing account management user is asked to enter their password
-    #When the existing account management user clicks link by href "https://signin.build.account.gov.uk/cookies"
-    #And the existing account management user accepts the cookie policy
-    #And the existing account management user clicks the go back link
-    #Then the existing account management user is asked to enter their password
-    #When the existing account management user clicks link by href "https://signin.build.account.gov.uk/cookies"
-    #When the existing account management user rejects the cookie policy
-    #And the existing account management user clicks the go back link
-    #Then the existing account management user is asked to enter their password
+  Scenario: Existing user updates their cookie preferences
+    Given the account management services are running
+    And the existing account management user has valid credentials
+    When the existing account management user navigates to account management
+    Then the existing account management user is taken to the your gov uk account page
+    When the existing account management user clicks link by href "/enter-password?type=changePhoneNumber"
+    Then the existing account management user is asked to enter their password
+    When the existing account management user clicks link by href "https://signin.build.account.gov.uk/cookies"
+    And the existing account management user accepts the cookie policy
+    Then the existing account management user is taken to the GOV.UK accounts cookies policy page
+    When the existing account management user rejects the cookie policy
+    Then the existing account management user is taken to the GOV.UK accounts cookies policy page
 
   Scenario: User changes their password
       Given the account management services are running


### PR DESCRIPTION
## What?

Re-adding the cookie preference scenario, up to the point where a user accepts/rejects cookies. 

## Why?

So these steps can be included in regression.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.