### PR TITLE
ACI-7: Do not block email when validation code entered incorrectly max times for new account

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
@@ -15,6 +15,8 @@ Feature: Locked accounts
     When the new user enters the six digit security code incorrectly 5 times
     When the new user enters an incorrect email code one more time
     Then the new user is taken to the security code invalid page
+    When the new user clicks link by href "/check-your-email"
+    Then the new user is asked to check their email
     When the new user visits the stub relying party
     And the new user clicks "govuk-signin-button"
     Then the new user is taken to the Identity Provider Login Page


### PR DESCRIPTION
## What?

Update the email lock test as a result of the following functional changes in ACI-7:

Do not block email when validation code entered incorrectly max times for new account.
Do not ask user to re-enter email when they request another code having exceeded the maximum.

## Why?

No reason to block the account if the account does not already exist, this just means the user has to wait 15 mins before they can create the account.
Make it easier for the user by not asking them to enter their email again.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2408
https://github.com/alphagov/di-authentication-frontend/pull/784