### PR TITLE
ACI-7: Do not block email when validation code entered incorrectly max times for new account

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -27,6 +27,7 @@ public enum AuthenticationJourneyPages {
     SHARE_INFO("/share-info", "Share information from your GOV.UK account"),
     SECURITY_CODE_INVALID(
             "/security-code-invalid", "You entered the wrong security code too many times"),
+    RESEND_EMAIL_CODE("resend-email-code", "Get security code"),
     RESEND_SECURITY_CODE("/resend-code", "Get security code"),
     RESEND_SECURITY_CODE_TOO_MANY_TIMES(
             "/security-code-requested-too-many-times",

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/LoginStepDefinitions.java
@@ -203,7 +203,8 @@ public class LoginStepDefinitions extends SignInStepDefinitions {
 
     @Then("the existing user is taken to the Welsh enter your email page")
     public void theExistingUserIsTakenToTheWelshEnterYourEmailPage() {
-        assertEquals("Rhowch eich cyfeiriad e-bost i fewngofnodi i'ch cyfrif GOV.UK - Cyfrif GOV.UK",
+        assertEquals(
+                "Rhowch eich cyfeiriad e-bost i fewngofnodi i'ch cyfrif GOV.UK - Cyfrif GOV.UK",
                 driver.getTitle());
         WebElement continueButton =
                 driver.findElement(By.cssSelector("#main-content > div > div > form > button"));

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/RegistrationStepDefinitions.java
@@ -187,6 +187,11 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
         waitForPageLoadThenValidate(SECURITY_CODE_INVALID);
     }
 
+    @Then("the new user is taken to the resend email code page")
+    public void theNewUserIsTakenToTheResendEmailCodePage() {
+        waitForPageLoadThenValidate(RESEND_EMAIL_CODE);
+    }
+
     @Then("the new user is taken to the create your password page")
     public void theNewUserIsAskedToCreateAPassword() {
         waitForPageLoadThenValidate(CREATE_PASSWORD);
@@ -213,8 +218,7 @@ public class RegistrationStepDefinitions extends SignInStepDefinitions {
 
     @When("the new user chooses text message security codes")
     public void theNewUserChoosesTextMessageSecurityCodes() {
-        WebElement radioTextMessageSecurityCodes =
-                driver.findElement(By.id("mfaOptions"));
+        WebElement radioTextMessageSecurityCodes = driver.findElement(By.id("mfaOptions"));
         radioTextMessageSecurityCodes.click();
         findAndClickContinue();
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/SignInStepDefinitions.java
@@ -91,7 +91,8 @@ public class SignInStepDefinitions {
     }
 
     protected void findAndClickContinueWelsh() {
-        WebElement continueButton = driver.findElement(By.cssSelector("#main-content > div > div > form > button"));
+        WebElement continueButton =
+                driver.findElement(By.cssSelector("#main-content > div > div > form > button"));
         continueButton.click();
     }
 

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
@@ -15,6 +15,10 @@ Feature: Locked accounts
     When the new user enters the six digit security code incorrectly 5 times
     When the new user enters an incorrect email code one more time
     Then the new user is taken to the security code invalid page
+    When the new user clicks link by href "/resend-email-code?requestNewCode=true"
+    Then the new user is taken to the resend email code page
+    When the new user clicks "resend-email-code"
+    Then the new user is asked to check their email
     When the new user visits the stub relying party
     And the new user clicks "govuk-signin-button"
     Then the new user is taken to the Identity Provider Login Page


### PR DESCRIPTION
## What?

Update the email lock test as a result of the following functional changes in ACI-7:

Do not block email when validation code entered incorrectly max times for new account.
Do not ask user to re-enter email when they request another code having exceeded the maximum.

## Why?

No reason to block the account if the account does not already exist, this just means the user has to wait 15 mins before they can create the account.
Make it easier for the user by not asking them to enter their email again.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2412
https://github.com/alphagov/di-authentication-frontend/pull/787