### PR TITLE
ACI-7: Add '/' to resend-email-code url

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/acceptance/AuthenticationJourneyPages.java
@@ -27,7 +27,7 @@ public enum AuthenticationJourneyPages {
     SHARE_INFO("/share-info", "Share information from your GOV.UK account"),
     SECURITY_CODE_INVALID(
             "/security-code-invalid", "You entered the wrong security code too many times"),
-    RESEND_EMAIL_CODE("resend-email-code", "Get security code"),
+    RESEND_EMAIL_CODE("/resend-email-code", "Get security code"),
     RESEND_SECURITY_CODE("/resend-code", "Get security code"),
     RESEND_SECURITY_CODE_TOO_MANY_TIMES(
             "/security-code-requested-too-many-times",


### PR DESCRIPTION
## What?

ACI-7: Add '/' to resend-email-code url

## Why?

Step:

'Then the new user is taken to the resend email code page'

is failing due to the missing '/'

## Related PRs

#149