### PR TITLE
ACI-7: Email no longer blocked

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/020_locked_accounts.feature
@@ -31,8 +31,6 @@ Feature: Locked accounts
     Then the new user is taken to the Identity Provider Login Page
     When the new user selects create an account
     Then the new user is taken to the enter your email page
-    When the new user enters their email address
-    Then the new user is taken to the security code invalid page
 
   Scenario: New user enters incorrect phone code 6 times
     Given the login services are running


### PR DESCRIPTION

## What?

Remove steps to check whether email is blocked when the user comes back having entered the security code incorrectly too many times.

## Why?

Now that the email is no longer blocked we won't show the security code invalid for the email.

## Related PRs

#150 
#149 