### PR TITLE
Aut 799 acceptance tests auth app add sign in scenario without 2fa

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
@@ -47,3 +47,13 @@ Feature: Authentication App Journeys
     When the new user clicks by name "logout"
     And there are no accessibility violations
     Then the new user is taken to the signed out page
+    When the user visits the stub relying party
+    And the existing user clicks "2fa-off"
+    And the existing user clicks "govuk-signin-button"
+    Then the existing user is taken to the Identity Provider Login Page
+    When the existing auth app user selects sign in
+    Then the existing auth app user is taken to the enter your email page
+    When the existing auth app user enters their email address
+    Then the existing auth app user is prompted for their password
+    When the existing auth app user enters their password
+    Then the user is returned to the service

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
@@ -57,3 +57,5 @@ Feature: Authentication App Journeys
     Then the existing auth app user is prompted for their password
     When the existing auth app user enters their password
     Then the user is returned to the service
+    When the new user clicks by name "logout"
+    Then the new user is taken to the signed out page


### PR DESCRIPTION
## What?

Expanding the Auth app sign in feature to include no 2FA and ensuring the user is not asked to enter an OTP from the Auth app.

## Why?

To have this scenario added to our regression.
