### PR TITLE
Added Auth app no 2FA login followed by uplift scenario.

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/000_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/000_auth_app_2fa_journey.feature
@@ -59,3 +59,20 @@ Feature: Authentication App Journeys
     Then the user is returned to the service
     When the new user clicks by name "logout"
     Then the new user is taken to the signed out page
+
+  Scenario: User signs in auth app without 2FA, then uplifts
+    Given the registration services are running
+    And the auth app user has valid credentials
+    When the user visits the stub relying party
+    And the existing user clicks "2fa-off"
+    And the existing user clicks "govuk-signin-button"
+    Then the existing user is taken to the Identity Provider Login Page
+    When the existing auth app user selects sign in
+    Then the existing auth app user is taken to the enter your email page
+    When the existing auth app user enters their email address
+    Then the existing auth app user is prompted for their password
+    When the existing auth app user enters their password
+    Then the user is returned to the service
+    When the user visits the stub relying party
+    And the existing user clicks "govuk-signin-button"
+    Then the existing user is taken to the Identity Provider Login Page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/005_auth_app_2fa_journey.feature
@@ -75,4 +75,4 @@ Feature: Authentication App Journeys
     Then the user is returned to the service
     When the user visits the stub relying party
     And the existing user clicks "govuk-signin-button"
-    Then the existing user is taken to the Identity Provider Login Page
+    Then the existing user is taken to the enter authenticator app code page


### PR DESCRIPTION
## What?

Added the uplift scenario from Auth sign in with No 2FA as it was throwing a 500 on the GET /uplift request. 

## Why?

To have this journey included in our regression.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/812