### PR TITLE
BAU: Update acceptance test defaults for pipeline

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/SignIn.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/SignIn.java
@@ -39,20 +39,19 @@ public class SignIn {
             System.getenv().getOrDefault("AM_URL", "https://build.account.gov.uk/");
 
     protected static final String TEST_USER_EMAIL =
-            System.getenv()
-                    .getOrDefault("TEST_USER_EMAIL", "rahul.gupta+2@digital.cabinet-office.gov.uk");
+            System.getenv().getOrDefault("TEST_USER_EMAIL", "");
 
     protected static final String TEST_USER_PASSWORD =
-            System.getenv().getOrDefault("TEST_USER_PASSWORD", "J3m3conn3ct312345");
+            System.getenv().getOrDefault("TEST_USER_PASSWORD", "");
 
     protected static final String TEST_USER_PHONE_CODE =
-            System.getenv().getOrDefault("TEST_USER_PHONE_CODE", "409722");
+            System.getenv().getOrDefault("TEST_USER_PHONE_CODE", "");
     protected static final Boolean SELENIUM_LOCAL =
             Boolean.parseBoolean(System.getenv().getOrDefault("SELENIUM_LOCAL", "false"));
     protected static final Boolean SELENIUM_HEADLESS =
             Boolean.parseBoolean(System.getenv().getOrDefault("SELENIUM_HEADLESS", "false"));
     protected static final Boolean DEBUG_MODE =
-            Boolean.parseBoolean(System.getenv().getOrDefault("DEBUG_MODE", "true"));
+            Boolean.parseBoolean(System.getenv().getOrDefault("DEBUG_MODE", "false"));
     protected static final String SELENIUM_BROWSER =
             System.getenv().getOrDefault("SELENIUM_BROWSER", FIREFOX_BROWSER);
     protected static final Duration DEFAULT_PAGE_LOAD_WAIT_TIME = Duration.of(20, SECONDS);


### PR DESCRIPTION

## What?

Update acceptance test defaults for pipeline.

## Why?

DEBUG_MODE was set to true by default, so tests where failing due to waiting for manual user input

## Related PRs

#166 