### PR TITLE
BAU: Change account created page title quote

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/RegistrationPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/RegistrationPage.java
@@ -9,7 +9,8 @@ public class RegistrationPage extends SignIn {
 
     By radioTextMessageSecurityCodes = By.id("mfaOptions");
     By secretKeyField = By.id("secret-key");
-    By iCannotScanQrCode = By.cssSelector("#main-content > div > div > details:nth-child(6) > summary");
+    By iCannotScanQrCode =
+            By.cssSelector("#main-content > div > div > details:nth-child(6) > summary");
     By goBackButton = By.cssSelector("#form-tracking > button");
     By radioShareInfoAccept = By.id("share-info-accepted");
     By deleteAccountButton = By.className("govuk-button--warning");
@@ -40,7 +41,9 @@ public class RegistrationPage extends SignIn {
         driver.findElement(signinToServiceButton).click();
     }
 
-    public void iCannotScanQrCodeClick() { driver.findElement(iCannotScanQrCode).click(); }
+    public void iCannotScanQrCodeClick() {
+        driver.findElement(iCannotScanQrCode).click();
+    }
 
     public String getSecretFieldText() {
         new WebDriverWait(driver, DEFAULT_PAGE_LOAD_WAIT_TIME)

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
@@ -19,7 +19,7 @@ public enum AuthenticationJourneyPages {
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
-    ACCOUNT_CREATED("/account-created", "You’ve created your GOV.UK account"),
+    ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
     ENTER_EMAIL_EXISTING_USER(


### PR DESCRIPTION

## What?

Change account created page title quote.

Spotless run on RegistrationPage.

## Why?

So that it matches what's displayed in the browser, tests are currently failing in the pipeline.

## Related PRs

#178 