### PR TITLE
AUT-911: Remove final AM dependencies + validation error fix

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/LoginPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/LoginPage.java
@@ -18,7 +18,7 @@ public class LoginPage extends SignIn {
     By securityCode = By.cssSelector("#main-content > div > div > form > button");
     By sixDigitSecurityCodeField = By.id("code");
     By emailDescriptionDetails = By.id("user-info-email");
-    By emailErrorDescriptionDetails = By.id("error-summary-title");
+    By emailErrorDescriptionDetails = By.className("govuk-error-summary");
 
     By continueButton = By.cssSelector("#main-content > div > div > form > button");
     By backButton = By.className("govuk-back-link");

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/AccountManagement.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/AccountManagement.java
@@ -43,11 +43,6 @@ public class AccountManagement extends SignIn {
         phoneNumber = System.getenv().get("TEST_USER_PHONE_NUMBER");
     }
 
-    @When("the existing account management user navigates to account management")
-    public void theExistingAccountManagementUserVisitsTheStubRelyingParty() {
-        driver.get(AM_URL.toString());
-    }
-
     @Then("the existing account management user is taken to the your gov uk account page")
     public void theExistingAccountManagementUserIsTakenToTheYourGovUkAccountPage() {
         waitForPageLoadThenValidate(YOUR_GOV_UK_ACCOUNT);

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/NotLoggedIn.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/NotLoggedIn.java
@@ -2,9 +2,11 @@ package uk.gov.di.test.step_definitions;
 
 import io.cucumber.java.AfterStep;
 import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import uk.gov.di.test.pages.LoginPage;
 import uk.gov.di.test.utils.SignIn;
 
 import java.net.MalformedURLException;
@@ -12,6 +14,8 @@ import java.net.MalformedURLException;
 import static uk.gov.di.test.utils.AuthenticationJourneyPages.SIGN_IN_OR_CREATE;
 
 public class NotLoggedIn extends SignIn {
+
+    public LoginPage loginPage = new LoginPage();
 
     @Before
     public void setupWebdriver() throws MalformedURLException {
@@ -26,9 +30,14 @@ public class NotLoggedIn extends SignIn {
     @Given("the not logged in services are running")
     public void theServicesAreRunning() {}
 
-    @When("the not logged in user navigates to account root")
-    public void theNotLoggedInUserNavigatesToAccountRoot() {
-        driver.get(AM_URL.toString());
+    @When("the not logged in user visits the stub relying party")
+    public void theNotLoggedInUserVisitsTheStubRelyingParty() {
+        driver.get(RP_URL.toString());
+    }
+
+    @And("the not logged in user clicks {string}")
+    public void theNotLoggedInUserClicks(String buttonName) {
+        loginPage.buttonClick(buttonName);
     }
 
     @Then("the not logged in user is taken to the Identity Provider Login Page")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/SignIn.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/SignIn.java
@@ -35,8 +35,6 @@ public class SignIn {
                     .getOrDefault(
                             "RP_URL",
                             "https://di-auth-stub-relying-party-build-s2.london.cloudapps.digital/");
-    protected static final String AM_URL =
-            System.getenv().getOrDefault("AM_URL", "https://build.account.gov.uk/");
 
     protected static final String TEST_USER_EMAIL =
             System.getenv().getOrDefault("TEST_USER_EMAIL", "");

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/001_not_logged_in.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/001_not_logged_in.feature
@@ -1,7 +1,8 @@
 Feature: Not logged in
-  User launches account management
+  User launches the stub
 
-  Scenario: User launches account management
+  Scenario: User launches the stub
     Given the not logged in services are running
-    When the not logged in user navigates to account root
+    When the not logged in user visits the stub relying party
+    And the not logged in user clicks "govuk-signin-button"
     Then the not logged in user is taken to the Identity Provider Login Page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/006_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/006_registration_journey.feature
@@ -17,7 +17,8 @@ Feature: Registration Journey
 
   Scenario: User redirects to Sign-in to a service from No GOV.UK Account found page
     Given a new user has valid credentials
-    When the not logged in user navigates to account root
+    When the not logged in user visits the stub relying party
+    And the not logged in user clicks "govuk-signin-button"
     Then the new user is taken to the Identity Provider Login Page
     When the new user selects sign in
     Then the new user is taken to the sign in to your account page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
@@ -20,7 +20,9 @@ Feature: Login Journey
 
   Scenario: Existing user tries to create an account with the same email address
     Given the existing account management user has valid credentials
-    When the existing account management user navigates to account management
+    When the existing user visits the stub relying party
+    And the existing user clicks "govuk-signin-button"
+    Then the existing user is taken to the Identity Provider Login Page
     And the existing account management user selects create an account
     Then the exiting account management user is asked to enter their current email address
     When the existing account management user enters their current email address
@@ -44,7 +46,9 @@ Feature: Login Journey
 
   Scenario: Existing user switches content to Welsh
     Given the existing user has valid credentials
-    When the existing account management user navigates to account management
+    When the existing user visits the stub relying party
+    And the existing user clicks "govuk-signin-button"
+    Then the existing user is taken to the Identity Provider Login Page
     And the existing account management user clicks link by href "?lng=cy"
     Then the existing user is taken to the Identity Provider Welsh Login Page
     When the existing user selects sign in


### PR DESCRIPTION
## What?

Remove final AM dependencies + validation error fix.

Tweak how the acceptance tests find validation errors in a page.

## Why?

Remove the last things that depend on AM.  Removes the requirement for an Auth instance of AM in build.  Following this the AM tasks can be removed from the pipeline.

The PR below changed how validation errors are displayed in a page so the tests need to be updated.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/898