### PR TITLE
AUT-1042: Use ‘smart quotes’ when checking page titles

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
@@ -19,7 +19,7 @@ public enum AuthenticationJourneyPages {
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
-    ACCOUNT_CREATED("/account-created", "You've created your GOV.UK account"),
+    ACCOUNT_CREATED("/account-created", "You’ve created your GOV.UK account"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
     ENTER_EMAIL_EXISTING_USER(


### PR DESCRIPTION

## What?

 Use ‘smart quotes’ when checking page titles. 

## Why?

All text in the application has been updated to use smart quotes, so update the tests too.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/910