### PR TITLE
BAU: Acceptance test change for name change to GOV.UK One Login

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/DocApp.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/DocApp.java
@@ -62,7 +62,7 @@ public class DocApp extends SignIn {
 
     @Then("the user is taken to the sign in page")
     public void theUserIsTakenToTheSignInPage() {
-        waitForPageLoad("Create a GOV.UK account or sign in");
+        waitForPageLoad("Create a GOV.UK One Login or sign in");
         assertTrue(driver.getCurrentUrl().contains("/sign-in-or-create"));
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LegalAndPolicy.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LegalAndPolicy.java
@@ -45,9 +45,9 @@ public class LegalAndPolicy extends SignIn {
 
     @Then("the user is taken to the Identity Provider Login Page")
     public void theExistingUserIsTakenToTheIdentityProviderLoginPage() {
-        waitForPageLoad("Create a GOV.UK account or sign in");
+        waitForPageLoad("Create a GOV.UK One Login or sign in");
         assertEquals("/sign-in-or-create", URI.create(driver.getCurrentUrl()).getPath());
-        assertEquals("Create a GOV.UK account or sign in - GOV.UK account", driver.getTitle());
+        assertEquals("Create a GOV.UK One Loging or sign in - GOV.UK One Login", driver.getTitle());
     }
 
     @And("the user clicks link {string}")
@@ -101,9 +101,9 @@ public class LegalAndPolicy extends SignIn {
 
     @Then("the new user is taken to the updated terms and conditions page")
     public void theNewUserIsTakenToTheUpdatedTermsAndConditionsPage() {
-        waitForPageLoad("GOV.UK account terms of use update");
+        waitForPageLoad("GOV.UK One Login terms of use update");
         assertEquals("/updated-terms-and-conditions", URI.create(driver.getCurrentUrl()).getPath());
-        assertEquals("GOV.UK account terms of use update - GOV.UK account", driver.getTitle());
+        assertEquals("GOV.UK One Login terms of use update - GOV.UK One Login", driver.getTitle());
     }
 
     @Then("the new user is taken to the Agree to the updated terms of use to continue page")
@@ -113,7 +113,7 @@ public class LegalAndPolicy extends SignIn {
                 "/updated-terms-and-conditions-disagree",
                 URI.create(driver.getCurrentUrl()).getPath());
         assertEquals(
-                "Agree to the updated terms of use to continue - GOV.UK account",
+                "Agree to the updated terms of use to continue - GOV.UK One Login",
                 driver.getTitle());
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LegalAndPolicy.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LegalAndPolicy.java
@@ -47,7 +47,7 @@ public class LegalAndPolicy extends SignIn {
     public void theExistingUserIsTakenToTheIdentityProviderLoginPage() {
         waitForPageLoad("Create a GOV.UK One Login or sign in");
         assertEquals("/sign-in-or-create", URI.create(driver.getCurrentUrl()).getPath());
-        assertEquals("Create a GOV.UK One Loging or sign in - GOV.UK One Login", driver.getTitle());
+        assertEquals("Create a GOV.UK One Login or sign in - GOV.UK One Login", driver.getTitle());
     }
 
     @And("the user clicks link {string}")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Login.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Login.java
@@ -176,13 +176,13 @@ public class Login extends SignIn {
 
     @Then("the existing user is taken to the Identity Provider Welsh Login Page")
     public void theExistingUserIsTakenToTheIdentityProviderWelshLoginPage() {
-        assertEquals("Creu cyfrif GOV.UK neu fewngofnodi - Cyfrif GOV.UK", driver.getTitle());
+        assertEquals("Creu GOV.UK One Login neu fewngofnodi - GOV.UK One Login", driver.getTitle());
     }
 
     @Then("the existing user is taken to the Welsh enter your email page")
     public void theExistingUserIsTakenToTheWelshEnterYourEmailPage() {
         assertEquals(
-                "Rhowch eich cyfeiriad e-bost i fewngofnodi i’ch cyfrif GOV.UK - Cyfrif GOV.UK",
+                "Rhowch eich cyfeiriad e-bost i fewngofnodi i’ch GOV.UK One Login - GOV.UK One Login",
                 driver.getTitle());
         Assertions.assertNotEquals("Continue", loginPage.continueButtonText());
         Assertions.assertNotEquals("Back", loginPage.backButtonText());
@@ -190,12 +190,12 @@ public class Login extends SignIn {
 
     @Then("the existing user is prompted for their password in Welsh")
     public void theExistingUserIsPromptedForTheirPasswordInWelsh() {
-        assertEquals("Rhowch eich cyfrinair - Cyfrif GOV.UK", driver.getTitle());
+        assertEquals("Rhowch eich cyfrinair - GOV.UK One Login", driver.getTitle());
     }
 
     @Then("the existing user is taken to the Welsh enter code page")
     public void theExistingUserIsTakenToTheWelshEnterCodePage() {
-        assertEquals("Gwiriwch eich ffôn - Cyfrif GOV.UK", driver.getTitle());
+        assertEquals("Gwiriwch eich ffôn - GOV.UK One Login", driver.getTitle());
     }
 
     @When("the existing user enters their password in Welsh")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AccountJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AccountJourneyPages.java
@@ -11,11 +11,11 @@ public enum AccountJourneyPages {
     DELETE_ACCOUNT("/delete-account", "Are you sure you want to delete your GOV.UK account?"),
     ACCOUNT_DELETED_CONFIRMATION(
             "/account-deleted-confirmation", "You have deleted your GOV.UK account"),
-    ACCOUNT_EXISTS("/enter-password-account-exists", "You have a GOV.UK account"),
+    ACCOUNT_EXISTS("/enter-password-account-exists", "You have a GOV.UK One Login"),
     ENTER_NEW_MOBILE_PHONE_NUMBER("/change-phone-number", "Enter your new mobile phone number"),
     GOV_UK_ACCOUNTS_COOKIES("/cookies", "GOV.UK accounts cookies policy");
 
-    private static final String PRODUCT_NAME = "GOV.UK account";
+    private static final String PRODUCT_NAME = "GOV.UK One Login";
 
     private String route;
     private String shortTitle;

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
@@ -1,10 +1,10 @@
 package uk.gov.di.test.utils;
 
 public enum AuthenticationJourneyPages {
-    SIGN_IN_OR_CREATE("/sign-in-or-create", "Create a GOV.UK account or sign in"),
+    SIGN_IN_OR_CREATE("/sign-in-or-create", "Create a GOV.UK One Login or sign in"),
     ENTER_EMAIL("/enter-email", "Enter your email address"),
     ENTER_EMAIL_CREATE("/enter-email-create", "Enter your email address"),
-    ACCOUNT_NOT_FOUND("/account-not-found", "No GOV.UK account found"),
+    ACCOUNT_NOT_FOUND("/account-not-found", "No GOV.UK One Login found"),
     CANNOT_GET_NEW_SECURITY_CODE(
             "/resend-code", "You cannot get a new security code at the moment"),
     CHECK_YOUR_EMAIL("/check-your-email", "Check your email"),
@@ -19,12 +19,12 @@ public enum AuthenticationJourneyPages {
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
-    ACCOUNT_CREATED("/account-created", "You’ve created your GOV.UK account"),
+    ACCOUNT_CREATED("/account-created", "You’ve created your GOV.UK One Login"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
     ENTER_EMAIL_EXISTING_USER(
-            "/enter-email", "Enter your email address to sign in to your GOV.UK account"),
-    SHARE_INFO("/share-info", "Share information from your GOV.UK account"),
+            "/enter-email", "Enter your email address to sign in to your GOV.UK One Login"),
+    SHARE_INFO("/share-info", "Share information from your GOV.UK One Login"),
     SECURITY_CODE_INVALID(
             "/security-code-invalid", "You entered the wrong security code too many times"),
     RESEND_EMAIL_CODE("/resend-email-code", "Get security code"),
@@ -33,7 +33,7 @@ public enum AuthenticationJourneyPages {
             "/security-code-requested-too-many-times",
             "You asked to resend the security code too many times");
 
-    private static final String PRODUCT_NAME = "GOV.UK account";
+    private static final String PRODUCT_NAME = "GOV.UK One Login";
 
     private String route;
     private String shortTitle;

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/SupportingPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/SupportingPages.java
@@ -2,12 +2,12 @@ package uk.gov.di.test.utils;
 
 public enum SupportingPages {
     ACCESSIBILITY_STATEMENT(
-            "/accessibility-statement", "Accessibility statement for GOV.UK accounts"),
-    GOV_UK_ACCOUNTS_COOKIES("/cookies", "GOV.UK accounts cookies policy"),
+            "/accessibility-statement", "Accessibility statement for GOV.UK One Login"),
+    GOV_UK_ACCOUNTS_COOKIES("/cookies", "GOV.UK One Login cookies policy"),
     TERMS_AND_CONDITIONS("/terms-and-conditions", "Terms and conditions"),
     PRIVACY_NOTICE("/privacy-notice", "Privacy notice");
 
-    private static final String PRODUCT_NAME = "GOV.UK account";
+    private static final String PRODUCT_NAME = "GOV.UK One Login";
 
     private String route;
     private String shortTitle;


### PR DESCRIPTION
## What?

Acceptance test change for name change to GOV.UK One Login.

## Why?

Product name is changing so tests need to be updated.
