### PR TITLE
AUT-1132 - replaced Allure reporting with Cucumber reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,20 +75,8 @@ Cucumber feature files live in the acceptance-tests [resources](acceptance-tests
 
 Java classes backing the tests live in the acceptance-tests java [acceptance](acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/) directory.
 
-## Allure reporting
-
-Allure Framework is a flexible lightweight multi-language test report tool that shows a clear representation of what has been tested in a web report form. It allows extraction of useful information such as coverage, execution timeline etc... from the execution of tests.
-
-Mac:
-brew install allure
-
-Windows:
-scoop install allure
-or
-npm i allure-commandline
+## Reporting
 
 Local report:
 
-1. Run the tests as usual, which will generate data in target/allure-results directory as set up in allure.properties
-2. run the allure serve command on the back of it followed by the allure-results path from the repository root so the results are uploaded to allure:
-allure serve acceptance-tests/target/allure-results
+Report is generated automatically - target/cucumber-report/index.html

--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -2,7 +2,6 @@
 plugins {
     id 'java'
     id 'maven-publish'
-    id 'io.qameta.allure' version '2.10.0'
 }
 
 repositories {
@@ -17,9 +16,7 @@ def dependencyVersions = [
         cucumber_version: '7.8.1',
         axe_version: '3.0',
         json_version: '20220320',
-        selenium_java_version: '4.5.0',
-        qameta_allure: '2.11.2',
-        qameta_allure_cucumber: '2.18.1'
+        selenium_java_version: '4.5.0'
 ]
 
 dependencies {
@@ -28,13 +25,10 @@ dependencies {
                        "org.seleniumhq.selenium:selenium-java:${dependencyVersions.selenium_java_version}",
                        "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
                        "commons-codec:commons-codec:1.15","io.github.cdimascio:java-dotenv:5.2.2",
-                       "io.qameta.allure:allure-maven:${dependencyVersions.qameta_allure}",
-                       "com.github.automatedowl:allure-environment-writer:1.0.0",
                        "commons-codec:commons-codec:1.15"
 
     testImplementation group: 'com.deque', name: 'axe-selenium', version:"${dependencyVersions.axe_version}"
     testImplementation group: 'org.json', name: 'json', version:"${dependencyVersions.json_version}"
-    testImplementation group: 'io.qameta.allure', name: 'allure-cucumber7-jvm', version:"${dependencyVersions.qameta_allure_cucumber}"
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit_version}"
 }
@@ -70,7 +64,7 @@ task cucumber() {
         javaexec {
             main = "io.cucumber.core.cli.Main"
             classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
-            args = ['--plugin', 'pretty', '--glue', 'uk.gov.di.test.step_definitions', 'src/test/resources', '--plugin', 'io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm']
+            args = ['--plugin', 'html:target/cucumber-report/index.html', '--plugin', 'pretty', '--glue', 'uk.gov.di.test.step_definitions', 'src/test/resources']
         }
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/runners/RunCucumberTest.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/runners/RunCucumberTest.java
@@ -5,5 +5,5 @@ import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"pretty"})
+@CucumberOptions(plugin = {"pretty", "html:target/cucumber-report/index.html"})
 public class RunCucumberTest {}

--- a/acceptance-tests/src/test/resources/allure.properties
+++ b/acceptance-tests/src/test/resources/allure.properties
@@ -1,2 +1,0 @@
-allure.link.tms.pattern=https://govukverify.atlassian.net/browse/{}
-allure.results.directory=target/allure-results


### PR DESCRIPTION
## What?

Replace Allure reporting with Cucumber reports.

## Why?

IA approval decision to allow use of Allure has now been reversed. Allure no longer to be used.