### PR TITLE
AUT-1162 - additional chrome option added to resolve http403 error

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/SignIn.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/SignIn.java
@@ -61,6 +61,7 @@ public class SignIn {
                 case CHROME_BROWSER:
                     ChromeOptions chromeOptions = new ChromeOptions();
                     chromeOptions.setHeadless(SELENIUM_HEADLESS);
+                    chromeOptions.addArguments("--remote-allow-origins=*");
                     if (SELENIUM_LOCAL) {
                         driver = new ChromeDriver(chromeOptions);
                     } else {


### PR DESCRIPTION
AUT-1162 - additional chrome option added to resolve http403 error

## What?

Additional ChromeOption added.

## Why?

To resolve http403 error introduced following a chrome browser/driver update.