### PR TITLE
AUT-995: Page title changes for password reset

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
@@ -14,8 +14,7 @@ public enum AuthenticationJourneyPages {
             "/get-security-codes", "Finish creating your account"),
     SETUP_AUTHENTICATOR_APP("/setup-authenticator-app", "Set up an authenticator app"),
     ENTER_AUTHENTICATOR_APP_CODE(
-            "/enter-authenticator-app-code",
-            "You need to enter a security code"),
+            "/enter-authenticator-app-code", "You need to enter a security code"),
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Enforce_100k_password_check.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Enforce_100k_password_check.feature
@@ -20,7 +20,7 @@ Feature: Enforce 100k password check
     When the user resets their password but enters mismatching new passwords
     Then the "Enter the same password in both fields" error message is displayed
     When the user enters valid new password and correctly retypes it
-    Then the user is taken to the "Check your phone" page
+    Then the user is taken to the "You need to enter a security code" page
     When the existing user enters the six digit security code from their phone
     Then the user is taken to the "Example - GOV.UK - User Info" page
     When the user clicks logout

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reset_password.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reset_password.feature
@@ -23,7 +23,7 @@ Feature: Reset password
     When the user resets their password but enters mismatching new passwords
     Then the "Enter the same password in both fields" error message is displayed
     When the user enters valid new password and correctly retypes it
-    Then the user is taken to the "Check your phone" page
+    Then the user is taken to the "You need to enter a security code" page
     When the existing user enters the six digit security code from their phone
     Then the user is taken to the "Example - GOV.UK - User Info" page
     When the user clicks logout


### PR DESCRIPTION
## What?

Page title changes for password reset.

## Why?

The page titles are in the feature files so were missed from a previous PR.

## Related PRs

#223 