### PR TITLE
BAU: Option to retrieve local config from SSM rather than a .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,41 @@ This repo contains automated browser based [Cucumber](https://cucumber.io/) test
 
 The tests can be run either in debug mode, where the tests will pause to accept entry of one-time password (OTP) codes before continuing, or in fully automated mode, where a test client is used to handle OTP.  The tests run in fully automated mode in the build pipeline.
 
-### Prerequisites
 
-1.  Clone the repo
-1.  Install Java 16+
-1.  Install Docker Desktop
-1.  Take a copy of [`.env.sample`](.env.sample) and rename it `.env`
-1.  Read the comments in `.env` for an explanation of the required configuration
-1.  Add the test email address and test phone number to the test [Notify](https://www.notifications.service.gov.uk/) team
+
+### Test configuration
+
+There are two different ways to retrieve configuration environment variables to run the tests:
+
+1. Use the ready-made configuration in AWS SSM Parameter Store
+2. Create a local .env file, either by exporting from SSM, or if required by hand.
+
+#### AWS SSM Parameter Store Configuration
+
+This is the default option if running the tests using `./run-acceptance-tests.sh`.  You need to have access to the `digital-identity-dev` AWS account and be on the VPN for it to work.  You do not need to create a local .env file to use this option.
 
 The configuration provided will connect to the build environment.
+
+#### Local .env Configuration
+
+To create a .env file based on the values in AWS SSM Parameter Store: 
+
+- Run `./run-acceptance-tests.sh -e`.  This will export a .env file with a timestamp.
+- Rename this file to `.env` before use.
+- Run `./run-acceptance-tests.sh -l` to make use of the local .env file.
+
+You do not need to be on the VPN to run the tests using an .env file.
+
+### Prerequisites
+
+1. Clone the repo
+2. Install Java 16+
+3. Install Docker Desktop
+4. Choose your configuration method as described in the previous section.
+
+### Clean up
+
+The `./run-acceptance-tests.sh` script will clean up the test data state after a test run by calling `./reset-test-data.sh`.
 
 ### Test Clients
 
@@ -34,12 +59,7 @@ A test client is needed to run in fully automated mode.  A test client:
 
 Using debug mode avoids the need to configure a test client, but means the UI will pause to allow OTP entry.
 
-1.  In `.env` set values for:
-    - TEST_USER_EMAIL
-    - TEST_USER_PASSWORD
-    - TEST_USER_PHONE_NUMBER
-    - TEST_USER_NEW_PASSWORD
-1.  Set:
+1.  In `.env` or `./run-acceptance-tests.sh` set:
     - SELENIUM_HEADLESS=false
     - DEBUG_MODE=true
 1.  Run: [./run-acceptance-tests.sh](run-acceptance-tests.sh)
@@ -51,14 +71,7 @@ Email and SMS OTP notifications will be sent to the email address and phone numb
 1.  Find a test client in a test environment
 1.  Add the test email address to `TestClientEmailAllowlist` in the client-registry database table for the test client
 1.  Configure secret email and phone OTP codes for testing
-1.  In `.env` set values for:
-    - TEST_USER_EMAIL
-    - TEST_USER_PASSWORD
-    - TEST_USER_PHONE_NUMBER
-    - TEST_USER_NEW_PASSWORD
-    - TEST_USER_EMAIL_CODE
-    - TEST_USER_PHONE_CODE
-1.  Set:
+1.  In `.env` or `./run-acceptance-tests.sh` set:
     - SELENIUM_HEADLESS=true
     - DEBUG_MODE=false
 1.  Run: [./run-acceptance-tests.sh](run-acceptance-tests.sh)
@@ -74,6 +87,14 @@ NOTES for now until further implementation (Ability to interact with the DB from
 Cucumber feature files live in the acceptance-tests [resources](acceptance-tests/src/test/resources/uk/gov/di/test/acceptance/) directory.
 
 Java classes backing the tests live in the acceptance-tests java [acceptance](acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/) directory.
+
+If new configuration environment variables or seed test data has been added remember to:
+
+1. Update the configuration under `/acceptance-tests/local` in AWS SSM Parameter Store.
+2. Create new test data if required in the [build pipeline](https://github.com/alphagov/di-infrastructure/blob/main/ci/tasks/generate-test-users-seed-data.yml).
+3. Pass any new environment variables to the tests for execution in the [build pipeline](https://github.com/alphagov/di-infrastructure/blob/9b1ae3c9a3114790ac758d7ac5cf4a28a470112b/ci/di-deployment-pipeline.yml#L1824).
+4. Change the cleanup script `./reset-test-data.sh` to reset any new test data if required.
+5. Do the same for the cleanup script in the [build pipeline](https://github.com/alphagov/di-infrastructure/blob/main/ci/tasks/reset-test-data.yml).
 
 ## Reporting
 

--- a/reset-test-data.sh
+++ b/reset-test-data.sh
@@ -2,99 +2,118 @@
 
 set -eu
 
-printf "\nResetting di-authentication-acceptance-tests test data...\n"
+LOCAL=0
+while getopts "l" opt; do
+  case ${opt} in
+    l)
+        LOCAL=1
+      ;;
+    *)
+        usage
+        exit 1
+      ;;
+  esac
+done
 
-export $(grep -v '^#' .env | xargs)
+echo -e "Resetting di-authentication-acceptance-tests test data..."
+
+if [ $LOCAL == "1" ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
 export AWS_REGION=eu-west-2
 export ENVIRONMENT_NAME=build
 export GDS_AWS_ACCOUNT=digital-identity-dev
 
+echo -e "Getting AWS credentials ..."
+eval "$(gds aws ${GDS_AWS_ACCOUNT} -e)"
+echo "done!"
+
 echo "Truncating test user data in user-profile..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-profile" \
     --key "{\"Email\": {\"S\": \"${TEST_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-credentials..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-credentials" \
     --key "{\"Email\": {\"S\": \"${TEST_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
-echo "Truncating test user data in user-profile..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-profile" \
     --key "{\"Email\": {\"S\": \"${PHONE_CODE_LOCK_TEST_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-credentials..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-credentials" \
     --key "{\"Email\": {\"S\": \"${PHONE_CODE_LOCK_TEST_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-profile..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-profile" \
     --key "{\"Email\": {\"S\": \"${TEST_USER_NEW_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-credentials..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-credentials" \
     --key "{\"Email\": {\"S\": \"${TEST_USER_NEW_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-profile..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-profile" \
     --key "{\"Email\": {\"S\": \"${TEST_USER_AUTH_APP_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-credentials..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-credentials" \
     --key "{\"Email\": {\"S\": \"${TEST_USER_AUTH_APP_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-profile..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-profile" \
     --key "{\"Email\": {\"S\": \"${IPN1_NEW_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-credentials..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-credentials" \
     --key "{\"Email\": {\"S\": \"${IPN1_NEW_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-profile..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-profile" \
     --key "{\"Email\": {\"S\": \"${IPN2_NEW_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-credentials..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-credentials" \
     --key "{\"Email\": {\"S\": \"${IPN2_NEW_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-profile..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-profile" \
     --key "{\"Email\": {\"S\": \"${IPN3_NEW_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "Truncating test user data in user-credentials..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb delete-item \
+aws dynamodb delete-item \
     --table-name "${ENVIRONMENT_NAME}-user-credentials" \
     --key "{\"Email\": {\"S\": \"${IPN3_NEW_USER_EMAIL}\"}}" \
     --region "${AWS_REGION}"
 
 echo "resetting terms and conditions version for test user in user-profile..."
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb update-item \
+aws dynamodb update-item \
     --table-name "${ENVIRONMENT_NAME}-user-profile" \
     --key "{\"Email\": {\"S\": \"${TERMS_AND_CONDITIONS_TEST_USER_EMAIL}\"}}" \
     --update-expression "SET #TC = :vtc" \
@@ -104,7 +123,7 @@ gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb update-item \
 
 echo "resetting password for reset password test user in user-credentials..."
 export HASHED_PASSWORD_RESET=$(echo -n "${RESET_PW_CURRENT_PW}" | argon2 $(openssl rand -hex 32) -e -id -v 13 -k 15360 -t 2 -p 1)
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb update-item \
+aws dynamodb update-item \
     --table-name "${ENVIRONMENT_NAME}-user-credentials" \
     --key "{\"Email\": {\"S\": \"${RESET_PW_USER_EMAIL}\"}}" \
     --update-expression "SET #PW = :vpw" \
@@ -114,7 +133,7 @@ gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb update-item \
 
 echo "resetting password for require password reset test user in user-credentials..."
 export HASHED_PASSWORD_REQ_RESET=$(echo -n "${REQ_RESET_PW_CURRENT_PW}" | argon2 $(openssl rand -hex 32) -e -id -v 13 -k 15360 -t 2 -p 1)
-gds-cli aws ${GDS_AWS_ACCOUNT} aws dynamodb update-item \
+aws dynamodb update-item \
     --table-name "${ENVIRONMENT_NAME}-user-credentials" \
     --key "{\"Email\": {\"S\": \"${REQ_RESET_PW_USER_EMAIL}\"}}" \
     --update-expression "SET #PW = :vpw" \

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -1,51 +1,99 @@
 #!/usr/bin/env bash
+
+set -eu
+
 DOCKER_BASE=docker-compose
-function wait_for_docker_services() {
-  RUNNING=0
-  LOOP_COUNT=0
-  echo -n "Waiting for service(s) to become healthy ($*) ."
-  until [[ ${RUNNING} == $# || ${LOOP_COUNT} == 100 ]]; do
-    RUNNING=$(${DOCKER_BASE} ps -q "$@" | xargs docker inspect | jq -rc '[ .[] | select(.State.Health.Status == "healthy")] | length')
-    LOOP_COUNT=$((LOOP_COUNT + 1))
-    echo -n "."
-  done
-  if [[ ${LOOP_COUNT} == 100 ]]; then
-    echo "FAILED"
-    return 1
-  fi
-  echo " done!"
-  return 0
-}
+SSM_VARS_PATH="/acceptance-tests/local"
+
+EXPORT_ENV=0
+LOCAL=0
+while getopts "le" opt; do
+  case ${opt} in
+    l)
+        LOCAL=1
+      ;;
+    e)
+        EXPORT_ENV=1
+      ;;
+    *)
+        usage
+        exit 1
+      ;;
+  esac
+done
 
 function start_docker_services() {
-  ${DOCKER_BASE} up --build -d --no-deps --quiet-pull "$@"
+  ${DOCKER_BASE} up --build -d --wait --no-deps --quiet-pull "$@"
 }
 
 function stop_docker_services() {
   ${DOCKER_BASE} down --rmi local --remove-orphans
 }
 
-function build_docker_service() {
-  ${DOCKER_BASE} build --quiet "$@"
+function get_env_vars_from_SSM() {
+  echo -n "Getting AWS credentials ... "
+  eval "$(gds aws digital-identity-dev -e)"
+  echo "done!"
+
+  echo "Getting environment variables from SSM ... "
+  if [ $EXPORT_ENV == "1" ]; then
+    dt="$(date "+%Y%m%d-%H%M%S")"
+    envfile="$dt.env"
+    echo "Exporting environment variables from SSM to file $envfile ... "
+    {
+      echo "#"
+      echo "# Acceptance test config exported from $SSM_VARS_PATH at $dt"
+      echo "#"
+      echo "# Rename to .env to use for testing"
+      echo "#"
+    } >> $envfile
+  fi
+
+  VARS="$(aws ssm get-parameters-by-path --region eu-west-2 --with-decryption --path $SSM_VARS_PATH | jq -r '.Parameters[] | @base64')"
+  for VAR in $VARS; do
+    VAR_NAME="$(echo ${VAR} | base64 -d | jq -r '.Name / "/" | .[3]')"
+    VAR_NAME_VALUE=$VAR_NAME="$(echo ${VAR} | base64 -d | jq -r '.Value')"
+    if [ $EXPORT_ENV == "1" ]; then
+      echo "$VAR_NAME_VALUE" >> $envfile
+    fi
+    export "$VAR_NAME"="$(echo ${VAR} | base64 -d | jq -r '.Value')"
+  done
+  echo "done!"
+  if [ $EXPORT_ENV == "1" ]; then
+    exit 0
+  fi
 }
 
-printf "\nBuilding di-authentication-acceptance-tests...\n"
+function export_selenium_config() {
+  export SELENIUM_URL="http://localhost:4444/wd/hub"
+  export SELENIUM_BROWSER=firefox
+  export SELENIUM_LOCAL=true
+  export SELENIUM_HEADLESS=false
+  export DEBUG_MODE=false
+}
+
+echo -e "Building di-authentication-acceptance-tests..."
 
 ./gradlew clean spotlessApply build -x :acceptance-tests:test
 
 build_and_test_exit_code=$?
 if [ ${build_and_test_exit_code} -ne 0 ]
 then
-    printf "\nacceptance-tests failed.\n"
+    echo -e "acceptance-tests failed."
     exit 1
 fi
 
-printf "\nRunning di-authentication-acceptance-tests...\n"
+echo -e "Running di-authentication-acceptance-tests..."
 
 start_docker_services selenium-firefox selenium-chrome
-sleep 5
 
-export $(grep -v '^#' .env | xargs)
+if [ $LOCAL == "1" ]; then
+  export_selenium_config
+  export $(grep -v '^#' .env | xargs)
+else
+  export_selenium_config
+  get_env_vars_from_SSM
+fi
 
 ./gradlew cucumber
 
@@ -55,8 +103,10 @@ stop_docker_services selenium-firefox selenium-chrome
 
 if [ ${build_and_test_exit_code} -ne 0 ]
 then
-    printf "\nacceptance-tests failed.\n"
+    echo -e "acceptance-tests failed."
 
 else
-    printf "\nacceptance-tests SUCCEEDED.\n"
+    echo -e "acceptance-tests SUCCEEDED."
 fi
+
+./reset-test-data.sh


### PR DESCRIPTION
## What?

Option to retrieve local config from SSM rather than a .env file.

Enables a user on the VPM with AWS access to run the acceptance tests without having to worry about creating a local configuration file. 

The ready-made configuration runs the tests against the application deployed in the build environment.  At the moment there is no option to point the tests against a local running (frontend) application.

## Why?

Makes it easier for everyone to run the tests.