### PR TITLE
AUT-995: Refactor tests for uplifting from 1FA to a 2FA service

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Login.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Login.java
@@ -147,6 +147,11 @@ public class Login extends SignIn {
         waitForPageLoadThenValidate(ENTER_CODE);
     }
 
+    @Then("the existing user is taken to the enter code uplifted page")
+    public void theExistingUserIsTakenToTheEnterCodePage() {
+        waitForPageLoadThenValidate(ENTER_CODE_UPLIFT);
+    }
+
     @When("the existing user enters the six digit security code from their phone")
     public void theExistingUserEntersTheSixDigitSecurityCodeFromTheirPhone() {
         if (DEBUG_MODE) {

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Registration.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Registration.java
@@ -312,6 +312,11 @@ public class Registration extends SignIn {
         waitForPageLoadThenValidate(ENTER_AUTHENTICATOR_APP_CODE);
     }
 
+    @Then("the existing user is taken to the enter authenticator app code uplifted page")
+    public void theNewUserIsTakenToTheEnterAuthenticatorAppCodeUpliftedPage() {
+        waitForPageLoadThenValidate(ENTER_AUTHENTICATOR_APP_CODE_UPLIFT);
+    }
+
     @Then("the new user is taken to the enter phone number page")
     public void theNewUserIsTakenToTheEnterPhoneNumberPage() {
         waitForPageLoadThenValidate(ENTER_PHONE_NUMBER);

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
@@ -16,12 +16,16 @@ public enum AuthenticationJourneyPages {
     ENTER_AUTHENTICATOR_APP_CODE(
             "/enter-authenticator-app-code",
             "Enter the 6 digit security code shown in your authenticator app"),
+    ENTER_AUTHENTICATOR_APP_CODE_UPLIFT(
+            "/enter-authenticator-app-code",
+            "You need to enter a security code"),
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),
     ACCOUNT_CREATED("/account-created", "You’ve created your GOV.UK One Login"),
     ENTER_PASSWORD("/enter-password", "Enter your password"),
     ENTER_CODE("/enter-code", "Check your phone"),
+    ENTER_CODE_UPLIFT("/enter-code", "You need to enter a security code"),
     ENTER_EMAIL_EXISTING_USER(
             "/enter-email", "Enter your email address to sign in to your GOV.UK One Login"),
     SHARE_INFO("/share-info", "Share information from your GOV.UK One Login"),

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
@@ -72,4 +72,4 @@ Feature: Authentication App Journeys
     Then the user is returned to the service
     When the user visits the stub relying party
     And the existing user clicks "govuk-signin-button"
-    Then the existing user is taken to the enter authenticator app code page
+    Then the existing user is taken to the enter authenticator app code uplifted page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
@@ -76,7 +76,7 @@ Feature: Login Journey
     Then the existing user is returned to the service
     When the existing user visits the stub relying party
     And the existing user clicks "govuk-signin-button"
-    Then the existing user is taken to the enter code page
+    Then the existing user is taken to the enter code uplifted page
     When the existing user enters the six digit security code from their phone
     Then the existing user is returned to the service
     When the user clicks logout


### PR DESCRIPTION
## What?

Refactor page title on the following pages when a user uplifts from a 1FA service to 2FA. The original page titles will remain the same, and only display the new ones when uplift is required.

- `/enter-code` page to `You need to enter a security code`
- `/enter-authenticator-app-code` page to `You need to enter a security code`

## Why?

So that a user signed in with 1FA understands why they are required to go through 2FA process in order to access the RP's service.

## Related PRs

[Frontend change](https://github.com/alphagov/di-authentication-frontend/pull/996)