### PR TITLE
AUT-995: Refactor duplicate method in Login step definitions

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Login.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Login.java
@@ -148,7 +148,7 @@ public class Login extends SignIn {
     }
 
     @Then("the existing user is taken to the enter code uplifted page")
-    public void theExistingUserIsTakenToTheEnterCodePage() {
+    public void theExistingUserIsTakenToTheEnterCodeUpliftedPage() {
         waitForPageLoadThenValidate(ENTER_CODE_UPLIFT);
     }
 

--- a/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/utils/AuthenticationJourneyPages.java
@@ -17,8 +17,7 @@ public enum AuthenticationJourneyPages {
             "/enter-authenticator-app-code",
             "Enter the 6 digit security code shown in your authenticator app"),
     ENTER_AUTHENTICATOR_APP_CODE_UPLIFT(
-            "/enter-authenticator-app-code",
-            "You need to enter a security code"),
+            "/enter-authenticator-app-code", "You need to enter a security code"),
     ENTER_PHONE_NUMBER("/enter-phone-number", "Enter your mobile phone number"),
     FINISH_CREATING_YOUR_ACCOUNT("/enter-phone-number", "Finish creating your account"),
     CHECK_YOUR_PHONE("/check-your-phone", "Check your phone"),


### PR DESCRIPTION
## What?

Fixes test failure for duplicated test method in Login step definition

## Related PRs
[original PR](https://github.com/alphagov/di-authentication-acceptance-tests/pull/229)