### PR TITLE
AUT-1201 updated secret length assertion to 32

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Registration.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Registration.java
@@ -265,7 +265,7 @@ public class Registration extends SignIn {
     public void theNewUserAddTheSecretKeyOnTheScreenToTheirAuthApp() {
         registrationPage.iCannotScanQrCodeClick();
         authAppSecretKey = registrationPage.getSecretFieldText();
-        assertTrue(registrationPage.getSecretFieldText().length() == 52);
+        assertTrue(registrationPage.getSecretFieldText().length() == 32);
     }
 
     @And("the user enters the security code from the auth app")


### PR DESCRIPTION
## What?

Change assertion expected result from 52 to 32.

## Why?

To align the acc tests with the auth app secret change from 52 to 32 chars.