### PR TITLE
AUT-1197: Change auth app secret key length validation from 52 to 32

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Registration.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Registration.java
@@ -265,7 +265,7 @@ public class Registration extends SignIn {
     public void theNewUserAddTheSecretKeyOnTheScreenToTheirAuthApp() {
         registrationPage.iCannotScanQrCodeClick();
         authAppSecretKey = registrationPage.getSecretFieldText();
-        assertTrue(registrationPage.getSecretFieldText().length() == 52);
+        assertTrue(registrationPage.getSecretFieldText().length() == 32);
     }
 
     @And("the user enters the security code from the auth app")


### PR DESCRIPTION
## What?

Change auth app secret key length validation from 52 to 32

## Why?

The screen has changed so that the secret key length is 32 rather than 52.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/1034