### PR TITLE
BAU: Add reset-test-data.yml concourse task to this repo

### DIFF
--- a/ci/tasks/reset-test-data.yml
+++ b/ci/tasks/reset-test-data.yml
@@ -1,0 +1,153 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: ((readonly_private_ecr_repo_name))
+    tag: di-toolbox-latest
+    aws_access_key_id: ((readonly_access_key_id))
+    aws_secret_access_key: ((readonly_secret_access_key))
+    aws_session_token: ((readonly_session_token))
+    aws_region: eu-west-2
+inputs:
+  - name: di-authentication-acceptance-tests
+params:
+  ENVIRONMENT_NAME: build
+  DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
+  TEST_USER_EMAIL: ((test-user-email))
+  EMAIL_CODE_LOCK_TEST_USER_EMAIL: ((test-user-email-lock-email))
+  PHONE_CODE_LOCK_TEST_USER_EMAIL: ((test-user-phone-lock-email))
+  TEST_USER_NEW_EMAIL: ((test-user-new-email))
+  TERMS_AND_CONDITIONS_TEST_USER_EMAIL: ((test-user-terms-and-conditions-email))
+  TEST_USER_AUTH_APP_EMAIL: ((test-user-auth-app-email))
+  IPN1_NEW_USER_EMAIL: ((test-user-new-email-ip1))
+  IPN2_NEW_USER_EMAIL: ((test-user-new-email-ip2))
+  IPN3_NEW_USER_EMAIL: ((test-user-new-email-ip3))
+  RESET_PW_USER_EMAIL: ((test-user-reset-pw-email))
+  RESET_PW_CURRENT_PW: ((test-user-reset-pw-password))
+  REQ_RESET_PW_USER_EMAIL: ((test-user-req-reset-pw-email))
+  REQ_RESET_PW_CURRENT_PW: ((test-user-req-reset-pw-password))
+run:
+  path: /bin/bash
+  args:
+    - -c
+    - |
+      set -eu
+      
+      export AWS_REGION=eu-west-2
+      STS_TOKEN=$(aws sts assume-role --role-arn="${DEPLOYER_ROLE_ARN}" --role-session-name="truncate-test-data")
+      export AWS_ACCESS_KEY_ID="$(echo ${STS_TOKEN} | jq -r .Credentials.AccessKeyId)"
+      export AWS_SECRET_ACCESS_KEY="$(echo ${STS_TOKEN} | jq -r .Credentials.SecretAccessKey)"
+      export AWS_SESSION_TOKEN="$(echo ${STS_TOKEN} | jq -r .Credentials.SessionToken)"
+      
+      echo "Truncating test user data in user-profile..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-profile" \
+          --key "{\"Email\": {\"S\": \"${TEST_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-credentials..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-credentials" \
+          --key "{\"Email\": {\"S\": \"${TEST_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-profile..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-profile" \
+          --key "{\"Email\": {\"S\": \"${PHONE_CODE_LOCK_TEST_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-credentials..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-credentials" \
+          --key "{\"Email\": {\"S\": \"${PHONE_CODE_LOCK_TEST_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-profile..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-profile" \
+          --key "{\"Email\": {\"S\": \"${TEST_USER_NEW_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-credentials..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-credentials" \
+          --key "{\"Email\": {\"S\": \"${TEST_USER_NEW_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-profile..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-profile" \
+          --key "{\"Email\": {\"S\": \"${TEST_USER_AUTH_APP_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-credentials..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-credentials" \
+          --key "{\"Email\": {\"S\": \"${TEST_USER_AUTH_APP_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+
+      echo "Truncating test user data in user-profile..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-profile" \
+          --key "{\"Email\": {\"S\": \"${IPN1_NEW_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-credentials..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-credentials" \
+          --key "{\"Email\": {\"S\": \"${IPN1_NEW_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+
+      echo "Truncating test user data in user-profile..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-profile" \
+          --key "{\"Email\": {\"S\": \"${IPN2_NEW_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-credentials..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-credentials" \
+          --key "{\"Email\": {\"S\": \"${IPN2_NEW_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+
+      echo "Truncating test user data in user-profile..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-profile" \
+          --key "{\"Email\": {\"S\": \"${IPN3_NEW_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "Truncating test user data in user-credentials..."
+      aws dynamodb delete-item \
+          --table-name "${ENVIRONMENT_NAME}-user-credentials" \
+          --key "{\"Email\": {\"S\": \"${IPN3_NEW_USER_EMAIL}\"}}" \
+          --region "${AWS_REGION}"
+      
+      echo "resetting terms and conditions version for test user in user-profile..."
+      aws dynamodb update-item \
+          --table-name "${ENVIRONMENT_NAME}-user-profile" \
+          --key "{\"Email\": {\"S\": \"${TERMS_AND_CONDITIONS_TEST_USER_EMAIL}\"}}" \
+          --update-expression "SET #TC = :vtc" \
+          --expression-attribute-names "{ \"#TC\": \"termsAndConditions\" }" \
+          --expression-attribute-values "{ \":vtc\": { \"M\": { \"version\": { \"S\": \"1.0\"}, \"timestamp\": {\"S\": \"1970-01-01T00:00:00.000000\"} } } }" \
+          --region "${AWS_REGION}"
+
+      echo "resetting password for reset password test user in user-credentials..."
+      export HASHED_PASSWORD_RESET=$(echo -n "${RESET_PW_CURRENT_PW}" | argon2 $(openssl rand -hex 32) -e -id -v 13 -k 15360 -t 2 -p 1)
+      aws dynamodb update-item \
+        --table-name "${ENVIRONMENT_NAME}-user-credentials" \
+        --key "{\"Email\": {\"S\": \"${RESET_PW_USER_EMAIL}\"}}" \
+        --update-expression "SET #PW = :vpw" \
+        --expression-attribute-names "{ \"#PW\": \"Password\" }" \
+        --expression-attribute-values "{ \":vpw\": { \"S\": \"${HASHED_PASSWORD_RESET}\"} }" \
+        --region "${AWS_REGION}"
+      
+      echo "resetting password for require password reset test user in user-credentials..."
+      export HASHED_PASSWORD_REQ_RESET=$(echo -n "${REQ_RESET_PW_CURRENT_PW}" | argon2 $(openssl rand -hex 32) -e -id -v 13 -k 15360 -t 2 -p 1)
+      aws dynamodb update-item \
+        --table-name "${ENVIRONMENT_NAME}-user-credentials" \
+        --key "{\"Email\": {\"S\": \"${REQ_RESET_PW_USER_EMAIL}\"}}" \
+        --update-expression "SET #PW = :vpw" \
+        --expression-attribute-names "{ \"#PW\": \"Password\" }" \
+        --expression-attribute-values "{ \":vpw\": { \"S\": \"${HASHED_PASSWORD_REQ_RESET}\"} }" \
+        --region "${AWS_REGION}"


### PR DESCRIPTION
## What?

Add reset-test-data.yml concourse task to this repo.

## Why?

Working towards a single task to setup and reset acceptance test data.  Next step is to remove this task from di-infrastructure and then repoint the pipeline to the task in this repo instead.  Planning to make use of a local script with reset functions that can be used both locally and by the pipeline.
