### PR TITLE
AUT-1337 - added capability to capture screenshot and add to test report on failure

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Hooks.java
@@ -1,12 +1,17 @@
 package uk.gov.di.test.step_definitions;
 
+import io.cucumber.java.After;
 import io.cucumber.java.AfterStep;
 import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
 import uk.gov.di.test.utils.SignIn;
 
 import java.net.MalformedURLException;
 
 public class Hooks extends SignIn {
+
     @Before
     public void setupWebdriver() throws MalformedURLException {
         super.setupWebdriver();
@@ -16,5 +21,13 @@ public class Hooks extends SignIn {
     @AfterStep
     public void checkAccessibility() {
         Axe.thereAreNoAccessibilityViolations();
+    }
+
+    @After
+    public void takeScreenshotOnFailure(Scenario scenario) {
+        if (scenario.isFailed()) {
+            final byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+            scenario.attach(screenshot, "image/png", "Failure screenshot");
+        }
     }
 }


### PR DESCRIPTION
## What?

Added capability to capture a screenshot and add it to the Cucumber report when a test fails.

## Why?

- May help with debug when there are issue
- Screenshot capture on failure is a QA team requirement