### PR TITLE
BAU: Acceptance test scripts to support both pipelines and local running

### DIFF
--- a/.github/workflows/build-and-push-tests.yaml
+++ b/.github/workflows/build-and-push-tests.yaml
@@ -3,7 +3,7 @@ name: Build and Push Acceptance Tests
 on:
   push:
     branches:
-      - BAU/run-test-new-pipeline
+      - main
 
 jobs:
   build:

--- a/.github/workflows/build-and-push-tests.yaml
+++ b/.github/workflows/build-and-push-tests.yaml
@@ -1,0 +1,36 @@
+name: Build and Push Acceptance Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::761723964695:role/auth-deploy-pipeline-dev-GitHubActionsRole-17Z6L5D2KMOAC
+          aws-region: eu-west-2
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push acceptance tests image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: acceptance-tests-testrunnerimagerepository-yaqn2qfs5qn2
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/build-and-push-tests.yaml
+++ b/.github/workflows/build-and-push-tests.yaml
@@ -3,7 +3,7 @@ name: Build and Push Acceptance Tests
 on:
   push:
     branches:
-      - main
+      - BAU/run-test-new-pipeline
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM docker
+
+RUN apk update && apk add --update --no-cache \
+    bash \
+    curl \
+    openjdk17 \
+    jq \
+    firefox \
+    aws-cli \
+    uuidgen \
+    argon2
+
+# install geckodriver
+RUN curl -L https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz | tar xz -C /usr/local/bin
+
+COPY . /test
+
+ENTRYPOINT ["/test/run-acceptance-tests.sh"]

--- a/reset-test-data.sh
+++ b/reset-test-data.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+ENVIRONMENT=${1:-local}
+
 source ./scripts/database.sh
 source ./scripts/reset-test-users.sh
 
@@ -21,15 +23,17 @@ done
 echo -e "Resetting di-authentication-acceptance-tests test data..."
 
 export AWS_REGION=eu-west-2
-export ENVIRONMENT_NAME=build
+export ENVIRONMENT_NAME=$ENVIRONMENT
 export GDS_AWS_ACCOUNT=digital-identity-dev
 
 if [ $LOCAL == "1" ]; then
   export $(grep -v '^#' .env | xargs)
 fi
 
-echo -e "Getting AWS credentials ..."
-eval "$(gds aws ${GDS_AWS_ACCOUNT} -e)"
-echo "done!"
+if [ $LOCAL == "1" ]; then
+  echo -e "Getting AWS credentials ..."
+  eval "$(gds aws ${GDS_AWS_ACCOUNT} -e)"
+  echo "done!"
+fi
 
 resetTestUsers

--- a/reset-test-data.sh
+++ b/reset-test-data.sh
@@ -2,16 +2,19 @@
 
 set -eu
 
-ENVIRONMENT=${1:-local}
+ENVIRONMENT=${2:-build}
 
 source ./scripts/database.sh
 source ./scripts/reset-test-users.sh
 
 LOCAL=0
-while getopts "l" opt; do
+while getopts "lr" opt; do
   case ${opt} in
   l)
     LOCAL=1
+    ;;
+  r)
+    LOCAL=0
     ;;
   *)
     usage

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-ENVIRONMENT=${2:-build}
+ENVIRONMENT=${2:-local}
 
 DOCKER_BASE=docker-compose
 SSM_VARS_PATH="/acceptance-tests/$ENVIRONMENT"
@@ -98,6 +98,12 @@ if [ ${build_and_test_exit_code} -ne 0 ]; then
   exit 1
 fi
 
+if [ $LOCAL == "1" ]; then
+  ./reset-test-data.sh -l
+else
+  ./reset-test-data.sh -r $ENVIRONMENT
+fi
+
 echo -e "Running di-authentication-acceptance-tests..."
 
 start_docker_services selenium-firefox selenium-chrome
@@ -121,10 +127,4 @@ if [ ${build_and_test_exit_code} -ne 0 ]; then
 
 else
   echo -e "acceptance-tests SUCCEEDED."
-fi
-
-if [ $LOCAL == "1" ]; then
-  ./reset-test-data.sh -l
-else
-  ./reset-test-data.sh -r $ENVIRONMENT
 fi

--- a/run-acceptance-tests.sh
+++ b/run-acceptance-tests.sh
@@ -98,12 +98,6 @@ if [ ${build_and_test_exit_code} -ne 0 ]; then
   exit 1
 fi
 
-if [ $LOCAL == "1" ]; then
-  ./reset-test-data.sh -l
-else
-  ./reset-test-data.sh -r $ENVIRONMENT
-fi
-
 echo -e "Running di-authentication-acceptance-tests..."
 
 start_docker_services selenium-firefox selenium-chrome
@@ -114,6 +108,12 @@ if [ $LOCAL == "1" ]; then
 else
   export_selenium_config
   get_env_vars_from_SSM
+fi
+
+if [ $LOCAL == "1" ]; then
+  ./reset-test-data.sh -l
+else
+  ./reset-test-data.sh -r $ENVIRONMENT
 fi
 
 ./gradlew cucumber


### PR DESCRIPTION
## What?

Update the acceptance test script parameters so they can support being used in both the CodePipeline and Concourse pipelines, as well as being run locally.

- Add a new 'r' switch to retrieve config from ssm rather than an local .env
- Read the environment from the 2nd paramater rather than the first

## Why?

The scripts need to work when called from both pipelines, locally and against different target environments.

## Related PRs

#239 