### PR TITLE
AUT-1465: Remove test for not agreeing to updated Ts&Cs

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/TermsAndConditionsPage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/TermsAndConditionsPage.java
@@ -11,8 +11,4 @@ public class TermsAndConditionsPage extends SignIn {
     public void pressAgreeAndContinueButton() {
         driver.findElement(agreeAndContinueButton).click();
     }
-
-    public void clickIDoNotAgreeLink() {
-        driver.findElement(iDoNotAgreeLink).click();
-    }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Login.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/Login.java
@@ -456,11 +456,6 @@ public class Login extends SignIn {
         }
     }
 
-    @When("the user does not agree to the updated terms and conditions")
-    public void theUserDoesNotAgreeToTheUpdatedTermsAndConditions() {
-        termsAndConditionsPage.clickIDoNotAgreeLink();
-    }
-
     @When("the user agrees to the updated terms and conditions")
     public void theUserAgreesToTheUpdatedTermsAndConditions() {
         termsAndConditionsPage.pressAgreeAndContinueButton();

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
@@ -29,7 +29,6 @@ Feature: Legal and policy pages
     Then the user is taken to the "Check your phone" page
     When the existing user enters the six digit security code from their phone
     Then the user is taken to the "terms of use update" page
-    When the user does not agree to the updated terms and conditions
     Then the user is taken to the "Agree to the updated terms of use to continue" page
     When the user agrees to the updated terms and conditions
     Then the user is taken to the "Example - GOV.UK - User Info" page


### PR DESCRIPTION
## What?

Removes test for users not agreeing to updated Ts&Cs

## Why?

The service is being updated so that the option to select "I do not agree" is not available.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/1118