### PR TITLE
AUT-1465: Remove invalid assertion

### DIFF
--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
@@ -29,7 +29,6 @@ Feature: Legal and policy pages
     Then the user is taken to the "Check your phone" page
     When the existing user enters the six digit security code from their phone
     Then the user is taken to the "terms of use update" page
-    Then the user is taken to the "Agree to the updated terms of use to continue" page
     When the user agrees to the updated terms and conditions
     Then the user is taken to the "Example - GOV.UK - User Info" page
     When the user clicks logout


### PR DESCRIPTION
## What?
- Remove assertion about rejecting Ts and Cs, which points at a page that no longer exists

## Why?
- After removing the possibility of rejecting new Ts and Cs, the assertion of a new page is no longer correct

## Related PRs
- Builds on: https://github.com/alphagov/di-authentication-acceptance-tests/pull/266
