### PR TITLE
AUT-1888 removed references that specify new or existing user

### DIFF
--- a/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/pages/BasePage.java
@@ -1,6 +1,7 @@
 package uk.gov.di.test.pages;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -184,5 +185,10 @@ public class BasePage {
         String authAppCode = AuthAppStub.getAuthAppCode(authAppSecretKey);
         clearFieldAndEnter(authAppCodeField, authAppCode);
         findAndClickContinue();
+    }
+
+    public void setAnalyticsCookieTo(Boolean state) {
+        driver.manage()
+                .addCookie(new Cookie("cookies_preferences_set", "{\"analytics\":" + state + "}"));
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/CommonStepDef.java
@@ -2,8 +2,15 @@ package uk.gov.di.test.step_definitions;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 import uk.gov.di.test.pages.BasePage;
 import uk.gov.di.test.pages.CreateOrSignInPage;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CommonStepDef extends BasePage {
     public CreateOrSignInPage createOrSignInPage = new CreateOrSignInPage();
@@ -21,5 +28,47 @@ public class CommonStepDef extends BasePage {
     @When("the user switches to Welsh language")
     public void theUserSwitchesToWelshLanguage() {
         createOrSignInPage.switchLanguageTo("Welsh");
+    }
+
+    @When("the user selects link {string}")
+    public void theUserSelectsLink(String linkText) {
+        selectLinkByText(linkText);
+    }
+
+    @When("the user selects {string} link")
+    public void theUserSelectsProblemsWithTheCode(String text) {
+        selectLinkByText(text);
+    }
+
+    @Then("the link {string} is not available")
+    public void theLinkIsNotAvailable(String linkText) {
+        assertFalse(isLinkTextDisplayed(linkText));
+    }
+
+    @When("the user clicks the continue button")
+    public void theUserClicksTheContinueButton() {
+        findAndClickContinue();
+    }
+
+    @Then("the user is returned to the service")
+    public void theUserIsReturnedToTheService() {}
+
+    @Then("the user is shown an error message")
+    public void theUserIsShownAnErrorMessageOnTheEnterEmailPage() {
+        assertTrue(isErrorSummaryDisplayed());
+    }
+
+    @Then("the user is not shown any error messages")
+    public void theNewUserIsNotShownAnErrorMessage() {
+        List<WebElement> errorFields = driver.findElements(By.id("code-error"));
+        if (!errorFields.isEmpty()) {
+            System.out.println("setup-authenticator-app error: " + errorFields.get(0));
+        }
+        assertTrue(errorFields.isEmpty());
+    }
+
+    @When("the user clicks the Back link")
+    public void theNewUserClicksTheApplicationBackButton() {
+        pressBack();
     }
 }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/DocAppStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/DocAppStepDef.java
@@ -27,11 +27,6 @@ public class DocAppStepDef extends BasePage {
         driver.get(DOC_APP_URL.toString());
     }
 
-    @And("the user clicks the continue button")
-    public void theUserClicksTheContinueButton() {
-        docAppPage.continueButtonClick();
-    }
-
     @And("the user sends a valid json payload")
     public void theUserSendsAValidJsonPayload() {
         jsonPayLoad = "{\"test\" : \"example\"}";

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/LoginStepDef.java
@@ -10,7 +10,6 @@ import uk.gov.di.test.pages.CheckYourPhonePage;
 import uk.gov.di.test.pages.CreateOrSignInPage;
 import uk.gov.di.test.pages.EnterYourEmailAddressPage;
 import uk.gov.di.test.pages.EnterYourEmailAddressToSignInPage;
-import uk.gov.di.test.pages.EnterYourMobilePhoneNumberPage;
 import uk.gov.di.test.pages.EnterYourPasswordPage;
 import uk.gov.di.test.pages.GetSecurityCodePage;
 import uk.gov.di.test.pages.ResetYourPasswordPage;
@@ -20,13 +19,14 @@ import uk.gov.di.test.pages.YouAskedToResendTheSecurityCodeTooManyTimesPage;
 import uk.gov.di.test.pages.YouveChangedHowYouGetSecurityCodesPage;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.ENTER_CODE_UPLIFT;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.ENTER_EMAIL_EXISTING_USER;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.ENTER_PASSWORD;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.RESEND_SECURITY_CODE;
-import static uk.gov.di.test.utils.Constants.*;
+import static uk.gov.di.test.utils.Constants.INCORRECT_EMAIL_OTP_CODE;
+import static uk.gov.di.test.utils.Constants.INVALID_EMAIL;
+import static uk.gov.di.test.utils.Constants.INVALID_PASSWORD;
+import static uk.gov.di.test.utils.Constants.MISMATCHING_PASSWORD_1;
+import static uk.gov.di.test.utils.Constants.MISMATCHING_PASSWORD_2;
+import static uk.gov.di.test.utils.Constants.NEW_VALID_PASSWORD;
+import static uk.gov.di.test.utils.Constants.TOP_100K_PASSWORD;
 
 public class LoginStepDef extends BasePage {
 
@@ -35,8 +35,6 @@ public class LoginStepDef extends BasePage {
     public CheckYourEmailPage checkYourEmailPage = new CheckYourEmailPage();
     public YouveChangedHowYouGetSecurityCodesPage youveChangedHowYouGetSecurityCodes =
             new YouveChangedHowYouGetSecurityCodesPage();
-    public EnterYourMobilePhoneNumberPage enterYourMobilePhoneNumberPage =
-            new EnterYourMobilePhoneNumberPage();
     public TermsAndConditionsPage termsAndConditionsPage = new TermsAndConditionsPage();
     public EnterYourPasswordPage enterYourPasswordPage = new EnterYourPasswordPage();
     public CheckYourPhonePage checkYourPhonePage = new CheckYourPhonePage();
@@ -61,14 +59,9 @@ public class LoginStepDef extends BasePage {
         enterYourPasswordPage.clickForgottenPasswordLink();
     }
 
-    @When("the existing user selects sign in")
-    public void theExistingUserSelectsSignIn() {
+    @When("the user selects sign in")
+    public void theUserSelectsSignIn() {
         createOrSignInPage.clickSignInButton();
-    }
-
-    @Then("the existing user is taken to the enter your email page")
-    public void theNewUserIsTakenToTheEnterYourEmailPage() {
-        waitForPageLoadThenValidate(ENTER_EMAIL_EXISTING_USER);
     }
 
     @And("user enters {string} email address")
@@ -81,58 +74,43 @@ public class LoginStepDef extends BasePage {
         enterYourEmailAddressToSignInPage.enterEmailAddressAndContinue(INVALID_EMAIL);
     }
 
-    @Then("the existing user is prompted for their password")
-    public void theExistingUserIsPromptedForPassword() {
-        waitForPageLoadThenValidate(ENTER_PASSWORD);
-    }
-
-    @When("the existing auth app user enters their password")
-    @When("the existing user enters their password")
-    public void theExistingUserEntersTheirPassword() {
+    @When("the user enters their password")
+    public void theUserEntersTheirPassword() {
         enterYourPasswordPage.enterPasswordAndContinue(System.getenv().get("TEST_USER_PASSWORD"));
     }
 
-    @When("the existing user enters their new password")
-    public void theExistingUserEntersTheirNewPassword() {
+    @When("the user enters their new password")
+    public void theUserEntersTheirNewPassword() {
         enterYourPasswordPage.enterPasswordAndContinue(NEW_VALID_PASSWORD);
     }
 
-    @Then("the existing user is taken to the enter code uplifted page")
-    public void theExistingUserIsTakenToTheEnterCodeUpliftedPage() {
-        waitForPageLoadThenValidate(ENTER_CODE_UPLIFT);
-    }
-
-    @When("the new user enters the six digit security code from their phone")
-    @When("the existing user enters the six digit security code from their phone")
+    @When("the user enters the six digit security code from their phone")
     public void theExistingUserEntersTheSixDigitSecurityCodeFromTheirPhone() {
         checkYourPhonePage.enterPhoneCodeAndContinue(System.getenv().get("TEST_USER_PHONE_CODE"));
     }
 
-    @Then("the existing user is returned to the service")
-    public void theExistingUserIsReturnedToTheService() {}
-
-    @When("the existing user requests the phone otp code {int} times")
-    public void theExistingUserRequestsThePhoneOtpCodeTimes(int timesCodeIncorrect) {
+    @When("the user requests the phone otp code {int} times")
+    public void theUserRequestsThePhoneOtpCodeTimes(int timesCodeIncorrect) {
         for (int i = 0; i < timesCodeIncorrect; i++) {
             checkYourPhonePage.clickProblemsWithTheCodeLink();
             checkYourPhonePage.clickSendTheCodeAgainLink();
-            waitForPageLoadThenValidate(RESEND_SECURITY_CODE);
+            waitForPageLoad("Get security code");
             getSecurityCodePage.pressGetSecurityCodeButton();
         }
     }
 
-    @When("the existing user clicks the get a new code link")
-    public void theExistingUserClicksTheGetANewCodeLink() {
+    @When("the user clicks the get a new code link")
+    public void theUserClicksTheGetANewCodeLink() {
         youAskedToResendTheSecurityCodeTooManyTimesPage.clickGetANewCodeLink();
     }
 
-    @Then("the existing user is taken to the Identity Provider Welsh Login Page")
-    public void theExistingUserIsTakenToTheIdentityProviderWelshLoginPage() {
+    @Then("the user is taken to the Identity Provider Welsh Login Page")
+    public void theUserIsTakenToTheIdentityProviderWelshLoginPage() {
         assertEquals("Creu GOV.UK One Login neu fewngofnodi - GOV.UK One Login", driver.getTitle());
     }
 
-    @Then("the existing user is taken to the Welsh enter your email page")
-    public void theExistingUserIsTakenToTheWelshEnterYourEmailPage() {
+    @Then("the user is taken to the Welsh enter your email page")
+    public void theUserIsTakenToTheWelshEnterYourEmailPage() {
         assertEquals(
                 "Rhowch eich cyfeiriad e-bost i fewngofnodi i’ch GOV.UK One Login - GOV.UK One Login",
                 driver.getTitle());
@@ -140,8 +118,8 @@ public class LoginStepDef extends BasePage {
         Assertions.assertNotEquals("Back", enterYourEmailAddressPage.backButtonText());
     }
 
-    @Then("the existing user is prompted for their password in Welsh")
-    public void theExistingUserIsPromptedForTheirPasswordInWelsh() {
+    @Then("the user is prompted for their password in Welsh")
+    public void theUserIsPromptedForTheirPasswordInWelsh() {
         assertEquals("Rhowch eich cyfrinair - GOV.UK One Login", driver.getTitle());
     }
 
@@ -206,7 +184,7 @@ public class LoginStepDef extends BasePage {
         findAndClickContinue();
     }
 
-    @When("the existing user adds the secret key on the screen to their auth app")
+    @When("the user adds the secret key on the screen to their auth app")
     public void theNewUserAddTheSecretKeyOnTheScreenToTheirAuthApp() {
         authAppSecretKey = System.getenv().get("ACCOUNT_RECOVERY_USER_AUTH_APP_SECRET");
         setUpAnAuthenticatorAppPage.iCannotScanQrCodeClick();
@@ -214,17 +192,12 @@ public class LoginStepDef extends BasePage {
         assertTrue(setUpAnAuthenticatorAppPage.getSecretFieldText().length() == 32);
     }
 
-    @And("the existing user enters the security code from the auth app")
+    @And("the user enters the security code from the auth app")
     public void theNewUserEntersTheSecurityCodeFromTheAuthApp() {
         if (authAppSecretKey == null) {
             authAppSecretKey = System.getenv().get("ACCOUNT_RECOVERY_USER_AUTH_APP_SECRET");
         }
         setUpAnAuthenticatorAppPage.enterCorrectAuthAppCodeAndContinue(authAppSecretKey);
-    }
-
-    @Then("the link {string} is not available")
-    public void theLinkIsNotAvailable(String linkText) {
-        assertFalse(isLinkTextDisplayed(linkText));
     }
 
     @And("the user requests the email OTP code be sent again a further {int} times")
@@ -243,24 +216,8 @@ public class LoginStepDef extends BasePage {
         }
     }
 
-    @When("the user selects {string} link")
-    public void theUserSelectsProblemsWithTheCode(String text) {
-        selectLinkByText(text);
-    }
-
-    @When("the user enters their mobile phone number")
-    public void theUserEntersTheirMobilePhoneNumber() {
-        enterYourMobilePhoneNumberPage.enterUkPhoneNumberAndContinue(
-                System.getenv().get("TEST_USER_PHONE_NUMBER"));
-    }
-
-    @And("the existing user selects create an account")
-    public void theExistingUserSelectsCreateAnAccount() {
-        createOrSignInPage.clickCreateAGovUkOneLoginButton();
-    }
-
-    @When("the existing user switches to {string} language")
-    public void theExistingUserSwitchesLanguage(String language) {
+    @When("the user switches to {string} language")
+    public void theUserSwitchesLanguage(String language) {
         createOrSignInPage.switchLanguageTo(language);
     }
 
@@ -273,11 +230,6 @@ public class LoginStepDef extends BasePage {
             System.out.println("Incorrect code entry count: " + (index + 1));
             Thread.sleep(2000);
         }
-    }
-
-    @When("the user selects link {string}")
-    public void theUserSelectsLink(String linkText) {
-        selectLinkByText(linkText);
     }
 
     @When("the user agrees to the updated terms and conditions")

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RegistrationStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RegistrationStepDef.java
@@ -4,40 +4,21 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 import uk.gov.di.test.pages.BasePage;
 import uk.gov.di.test.pages.CheckYourEmailPage;
 import uk.gov.di.test.pages.ChooseHowToGetSecurityCodesPage;
 import uk.gov.di.test.pages.CreateOrSignInPage;
 import uk.gov.di.test.pages.CreateYourPasswordPage;
-import uk.gov.di.test.pages.EnterThe6DigitSecurityCodeShownInYourAuthenticatorAppPage;
 import uk.gov.di.test.pages.EnterYourEmailAddressPage;
 import uk.gov.di.test.pages.EnterYourMobilePhoneNumberPage;
-import uk.gov.di.test.pages.NoGovUkOneLoginFoundPage;
 import uk.gov.di.test.pages.RpStubPage;
-import uk.gov.di.test.pages.SetUpAnAuthenticatorAppPage;
 
-import java.net.URI;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.ACCOUNT_CREATED;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.CHECK_YOUR_EMAIL;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.CHECK_YOUR_PHONE;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.CREATE_PASSWORD;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.ENTER_EMAIL_CREATE;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.ENTER_PHONE_NUMBER;
-import static uk.gov.di.test.utils.AuthenticationJourneyPages.GET_SECURITY_CODES;
 import static uk.gov.di.test.utils.Constants.*;
 
 public class RegistrationStepDef extends BasePage {
 
-    private String authAppSecretKey;
-
-    NoGovUkOneLoginFoundPage noGovUkOneLoginFoundPage = new NoGovUkOneLoginFoundPage();
     EnterYourMobilePhoneNumberPage enterYourMobilePhoneNumberPage =
             new EnterYourMobilePhoneNumberPage();
     EnterYourEmailAddressPage enterYourEmailAddressPage = new EnterYourEmailAddressPage();
@@ -47,149 +28,54 @@ public class RegistrationStepDef extends BasePage {
     CreateYourPasswordPage createYourPasswordPage = new CreateYourPasswordPage();
     ChooseHowToGetSecurityCodesPage chooseHowToGetSecurityCodesPage =
             new ChooseHowToGetSecurityCodesPage();
-    SetUpAnAuthenticatorAppPage setUpAnAuthenticatorAppPage = new SetUpAnAuthenticatorAppPage();
-    EnterThe6DigitSecurityCodeShownInYourAuthenticatorAppPage
-            enterThe6DigitSecurityCodeShownInYourAuthenticatorAppPage =
-                    new EnterThe6DigitSecurityCodeShownInYourAuthenticatorAppPage();
 
     @When("the user selects create an account")
     public void theUserSelectsCreateAnAccount() {
-        createOrSignInPage.clickCreateAGovUkOneLoginButton();
-    }
-
-    @When("the new user selects create an account")
-    public void theNewUserSelectsCreateAnAccount() {
-        noGovUkOneLoginFoundPage.clickCreateGovUkOneLoginButton();
-    }
-
-    @Then("the new user is taken to the enter your email page")
-    public void theNewUserIsTakenToTheEnterYourEmailPage() {
-        waitForPageLoadThenValidate(ENTER_EMAIL_CREATE);
-    }
-
-    @When("the new user selects sign in")
-    public void theNewUserSelectsSignIn() {
-        createOrSignInPage.clickSignInButton();
-    }
-
-    @Then("the new user is asked to check their email")
-    public void theNewUserIsAskedToCheckTheirEmail() {
-        waitForPageLoadThenValidate(CHECK_YOUR_EMAIL);
+        findAndClickButtonByText("Create a GOV.UK One Login");
     }
 
     @When("the user enters the six digit security code from their email")
-    @When("the new user enters the six digit security code from their email")
-    public void theNewUserEntersTheSixDigitSecurityCodeFromTheirEmail() {
+    public void theUserEntersTheSixDigitSecurityCodeFromTheirEmail() {
         checkYourEmailPage.enterEmailCodeAndContinue(System.getenv().get("TEST_USER_EMAIL_CODE"));
     }
 
-    @Then("the new user is taken to the create your password page")
-    public void theNewUserIsAskedToCreateAPassword() {
-        waitForPageLoadThenValidate(CREATE_PASSWORD);
-    }
-
-    @And("the new user creates a password")
-    public void theNewUserCreatesAPassword() {
+    @And("the user creates a password")
+    public void theUserCreatesAPassword() {
         String passwordVal = System.getenv().get("TEST_USER_PASSWORD");
         createYourPasswordPage.enterBothPasswordsAndContinue(passwordVal, passwordVal);
     }
 
-    @And("the new user creates and enters an invalid password")
-    public void theNewUserCreatesAndEntersAnInvalidPassword() {
+    @And("the user creates and enters an invalid password")
+    public void theUserCreatesAndEntersAnInvalidPassword() {
         createYourPasswordPage.enterBothPasswordsAndContinue(INVALID_PASSWORD, INVALID_PASSWORD);
     }
 
-    @And("the new user creates and enters a weak password")
-    public void theNewUserCreatesAndEntersAWeakPassword() {
+    @And("the user creates and enters a weak password")
+    public void theUserCreatesAndEntersAWeakPassword() {
         createYourPasswordPage.enterBothPasswordsAndContinue(WEAK_PASSWORD, WEAK_PASSWORD);
     }
 
-    @And("the new user creates and enters short digit only password")
-    public void theNewUserCreatesAndEntersShortDigitOnlyPassword() {
+    @And("the user creates and enters short digit only password")
+    public void theUserCreatesAndEntersShortDigitOnlyPassword() {
         createYourPasswordPage.enterBothPasswordsAndContinue(
                 SHORT_DIGIT_PASSWORD, SHORT_DIGIT_PASSWORD);
     }
 
-    @And("the new user creates and enters a sequence of numbers password")
-    public void theNewUserCreatesAndEntersASequenceOfNumbersPassword() {
+    @And("the user creates and enters a sequence of numbers password")
+    public void theUserCreatesAndEntersASequenceOfNumbersPassword() {
         createYourPasswordPage.enterBothPasswordsAndContinue(
                 SEQUENCE_NUMBER_PASSWORD, SEQUENCE_NUMBER_PASSWORD);
     }
 
-    @Then("the new user is taken to the get security codes page")
-    public void theNewUserIsTakenToTheGetSecurityCodesPage() {
-        waitForPageLoadThenValidate(GET_SECURITY_CODES);
-    }
-
-    @When("the new user chooses {string} to get security codes")
-    public void theNewUserChoosesHowToGetSecurityCodes(String mfaMethod) {
+    @When("the user chooses {string} to get security codes")
+    public void theUserChoosesHowToGetSecurityCodes(String mfaMethod) {
         chooseHowToGetSecurityCodesPage.selectAuthMethodAndContinue(mfaMethod);
     }
 
-    @When("the new user adds the secret key on the screen to their auth app")
-    public void theNewUserAddTheSecretKeyOnTheScreenToTheirAuthApp() {
-        setUpAnAuthenticatorAppPage.iCannotScanQrCodeClick();
-        authAppSecretKey = setUpAnAuthenticatorAppPage.getSecretFieldText();
-        assertTrue(setUpAnAuthenticatorAppPage.getSecretFieldText().length() == 32);
-    }
-
-    @And("the user enters the security code from the auth app to set it up")
-    public void theNewUserEntersTheSecurityCodeFromTheAuthAppToSetItUp() {
-        setUpAnAuthenticatorAppPage.enterCorrectAuthAppCodeAndContinue(authAppSecretKey);
-    }
-
-    @And("the user enters the security code from the auth app")
-    public void theNewUserEntersTheSecurityCodeFromTheAuthApp() {
-        enterThe6DigitSecurityCodeShownInYourAuthenticatorAppPage
-                .enterCorrectAuthAppCodeAndContinue(authAppSecretKey);
-    }
-
-    @When("the existing auth app user selects sign in")
-    public void theExistingAuthAppUserSelectsSignIn() {
-        createOrSignInPage.clickSignInButton();
-    }
-
-    @Then("the new user is taken to the enter phone number page")
-    public void theNewUserIsTakenToTheEnterPhoneNumberPage() {
-        waitForPageLoadThenValidate(ENTER_PHONE_NUMBER);
-    }
-
-    @When("the new user enters their mobile phone number")
-    public void theNewUserEntersTheirMobilePhoneNumber() {
+    @When("the user enters their mobile phone number")
+    public void theUserEntersTheirMobilePhoneNumber() {
         enterYourMobilePhoneNumberPage.enterUkPhoneNumberAndContinue(
                 System.getenv().get("TEST_USER_PHONE_NUMBER"));
-    }
-
-    @Then("the new user is taken to the check your phone page")
-    public void theNewUserIsTakenToTheCheckYourPhonePage() {
-        waitForPageLoadThenValidate(CHECK_YOUR_PHONE);
-    }
-
-    @Then("the new user is taken to the account created page")
-    public void theNewUserIsTakenToTheSuccessPage() {
-        waitForPageLoadThenValidate(ACCOUNT_CREATED);
-    }
-
-    @When("the new user clicks the continue button")
-    public void theNewUserClicksTheContinueButton() {
-        findAndClickContinue();
-    }
-
-    @Then("the user is returned to the service")
-    public void theUserIsReturnedToTheService() {}
-
-    @Then("the user is shown an error message")
-    public void theUserIsShownAnErrorMessageOnTheEnterEmailPage() {
-        assertTrue(isErrorSummaryDisplayed());
-    }
-
-    @Then("the user is not shown any error messages")
-    public void theNewUserIsNotShownAnErrorMessage() {
-        List<WebElement> errorFields = driver.findElements(By.id("code-error"));
-        if (!errorFields.isEmpty()) {
-            System.out.println("setup-authenticator-app error: " + errorFields.get(0));
-        }
-        assertTrue(errorFields.isEmpty());
     }
 
     @When("the user clicks logout")
@@ -197,45 +83,34 @@ public class RegistrationStepDef extends BasePage {
         findAndClickButtonByText("Log out");
     }
 
-    @When("the user clicks the Back link")
-    public void theNewUserClicksTheApplicationBackButton() {
-        pressBack();
-    }
-
-    @Then("the new user is taken to the signed out page")
-    public void theNewUsereIsTakenToTheSignedOutPage() {
-        waitForPageLoad("Signed out");
-        assertEquals("/signed-out", URI.create(driver.getCurrentUrl()).getPath());
-    }
-
-    @When("the new user enters their mobile phone number using an international dialling code")
-    public void theNewUserEntersTheirMobilePhoneNumberUsingAnInternationalDiallingCode() {
+    @When("the user enters their mobile phone number using an international dialling code")
+    public void theUserEntersTheirMobilePhoneNumberUsingAnInternationalDiallingCode() {
         enterYourMobilePhoneNumberPage.enterUkPhoneNumberAndContinue(
                 System.getenv().get("TEST_USER_INTERNATIONAL_PHONE_NUMBER"));
     }
 
-    @When("the new user submits a blank UK phone number")
-    public void theNewUserSubmitsABlankUKPhoneNumber() {
+    @When("the user submits a blank UK phone number")
+    public void theUserSubmitsABlankUKPhoneNumber() {
         enterYourMobilePhoneNumberPage.enterUkPhoneNumberAndContinue("");
     }
 
-    @When("the new user submits an international phone number in the UK phone number field")
-    public void theNewUserSubmitsAnInternationalPhoneNumberInTheUKPhoneNumberField() {
+    @When("the user submits an international phone number in the UK phone number field")
+    public void theUserSubmitsAnInternationalPhoneNumberInTheUKPhoneNumberField() {
         enterYourMobilePhoneNumberPage.enterUkPhoneNumberAndContinue("+61412123123");
     }
 
-    @When("the new user submits an incorrectly formatted UK phone number")
-    public void theNewUserSubmitsAnIncorrectlyFormattedUKPhoneNumber() {
+    @When("the user submits an incorrectly formatted UK phone number")
+    public void theUserSubmitsAnIncorrectlyFormattedUKPhoneNumber() {
         enterYourMobilePhoneNumberPage.enterUkPhoneNumberAndContinue("070000000000000");
     }
 
-    @When("the new user submits a UK phone number containing non-digit characters")
-    public void theNewUserSubmitsAUKPhoneNumberContainingNonDigitCharacters() {
+    @When("the user submits a UK phone number containing non-digit characters")
+    public void theUserSubmitsAUKPhoneNumberContainingNonDigitCharacters() {
         enterYourMobilePhoneNumberPage.enterUkPhoneNumberAndContinue("0780312*a45");
     }
 
-    @When("the new user ticks I do not have a UK mobile number")
-    public void theNewUserTicksIDoNotHaveAUKMobileNumber() {
+    @When("the user ticks I do not have a UK mobile number")
+    public void theUserTicksIDoNotHaveAUKMobileNumber() {
         enterYourMobilePhoneNumberPage.tickIDoNotHaveUkMobileNumber();
     }
 
@@ -244,26 +119,25 @@ public class RegistrationStepDef extends BasePage {
         assertTrue(enterYourMobilePhoneNumberPage.isInternationalMobileNumberFieldDisplayed());
     }
 
-    @When("the new user submits a blank international mobile phone number")
-    public void theNewUserSubmitsABlankInternationalMobilePhoneNumber() {
+    @When("the user submits a blank international mobile phone number")
+    public void theUserSubmitsABlankInternationalMobilePhoneNumber() {
         enterYourMobilePhoneNumberPage.enterInternationalMobilePhoneNumberAndContinue("");
     }
 
-    @When("the new user submits an incorrectly formatted international mobile phone number")
-    public void theNewUserSubmitsAnIncorrectlyFormattedInternationalMobilePhoneNumber() {
+    @When("the user submits an incorrectly formatted international mobile phone number")
+    public void theUserSubmitsAnIncorrectlyFormattedInternationalMobilePhoneNumber() {
         enterYourMobilePhoneNumberPage.enterInternationalMobilePhoneNumberAndContinue(
                 "+123456789123456789123456");
     }
 
-    @When(
-            "the new user submits an international mobile phone number containing non-digit characters")
-    public void theNewUserSubmitsAnInternationalMobilePhoneNumberContainingNonDigitCharacters() {
+    @When("the user submits an international mobile phone number containing non-digit characters")
+    public void theUserSubmitsAnInternationalMobilePhoneNumberContainingNonDigitCharacters() {
         enterYourMobilePhoneNumberPage.enterInternationalMobilePhoneNumberAndContinue(
                 "/3383838383");
     }
 
-    @When("the new user enters a valid international mobile phone number")
-    public void theNewUserEntersAValidInternationalMobilePhoneNumber() {
+    @When("the user enters a valid international mobile phone number")
+    public void theUserEntersAValidInternationalMobilePhoneNumber() {
         enterYourMobilePhoneNumberPage.enterInternationalMobilePhoneNumberAndContinue(
                 "+61412123123");
     }

--- a/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
+++ b/acceptance-tests/src/test/java/uk/gov/di/test/step_definitions/RpStubStepDef.java
@@ -12,5 +12,6 @@ public class RpStubStepDef extends BasePage {
     public void theExistingUserVisitsTheStubRelyingParty(String options) {
         rpStubPage.goToRpStub();
         rpStubPage.selectRpOptionsByIdAndContinue(options);
+        setAnalyticsCookieTo(false);
     }
 }

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/003_legal_and_policy_pages.feature
@@ -18,13 +18,13 @@ Feature: Legal and policy pages
   Scenario: User accepts updated terms and conditions
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email" page
     When user enters "TERMS_AND_CONDITIONS_TEST_USER_EMAIL" email address
     Then the user is taken to the "Enter your password" page
-    When the existing user enters their password
+    When the user enters their password
     Then the user is taken to the "Check your phone" page
-    When the existing user enters the six digit security code from their phone
+    When the user enters the six digit security code from their phone
     Then the user is taken to the "terms of use update" page
     When the user agrees to the updated terms and conditions
     Then the user is taken to the "Example - GOV.UK - User Info" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/005_auth_app_2fa_journey.feature
@@ -9,28 +9,28 @@ Feature: Authentication App Journeys
     Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_AUTH_APP_EMAIL" email address
     Then the user is taken to the "Check your email" page
-    When the new user enters the six digit security code from their email
+    When the user enters the six digit security code from their email
     Then the user is taken to the "Create your password" page
-    When the new user creates a password
+    When the user creates a password
     Then the user is taken to the "Choose how to get security codes" page
-    When the new user chooses "Auth App" to get security codes
+    When the user chooses "Auth App" to get security codes
     Then the user is taken to the "Set up an authenticator app" page
-    When the new user adds the secret key on the screen to their auth app
-    And the user enters the security code from the auth app to set it up
+    When the user adds the secret key on the screen to their auth app
+    And the user enters the security code from the auth app
     Then the user is not shown any error messages
     And the user is taken to the "You’ve created your GOV.UK One Login" page
-    When the new user clicks the continue button
+    When the user clicks the continue button
     Then the user is returned to the service
     When the user clicks logout
     Then the user is taken to the "Signed out" page
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing auth app user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_AUTH_APP_EMAIL" email address
     Then the user is taken to the "Enter your password" page
-    When the existing auth app user enters their password
+    When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user enters the security code from the auth app
     Then the user is returned to the service
@@ -40,11 +40,11 @@ Feature: Authentication App Journeys
   Scenario: User successfully login without 2FA
     Given the user comes from the stub relying party with options: "2fa-off"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing auth app user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_AUTH_APP_EMAIL" email address
     Then the user is taken to the "Enter your password" page
-    When the existing auth app user enters their password
+    When the user enters their password
     Then the user is returned to the service
     When the user clicks logout
     Then the user is taken to the "Signed out" page
@@ -52,11 +52,11 @@ Feature: Authentication App Journeys
   Scenario: User signs in auth app without 2FA, then uplifts
     Given the user comes from the stub relying party with options: "2fa-off"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing auth app user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_AUTH_APP_EMAIL" email address
     Then the user is taken to the "Enter your password" page
-    When the existing auth app user enters their password
+    When the user enters their password
     Then the user is returned to the service
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "You need to enter a security code" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/006_registration_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/006_registration_journey.feature
@@ -5,7 +5,7 @@ Feature: Registration Journey
   Scenario: User selects sign in without having an account
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the new user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email address to sign in to your GOV.UK One Login" page
     When user enters "TEST_USER_EMAIL" email address
     Then the user is taken to the "No GOV.UK One Login found" page
@@ -29,56 +29,56 @@ Feature: Registration Journey
   Scenario: User is taken to Check your email page from No GOV.UK One Login found page when Create selected
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the new user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email address to sign in to your GOV.UK One Login" page
     When user enters "TEST_USER_EMAIL" email address
     Then the user is taken to the "No GOV.UK One Login found" page
-    When the new user selects create an account
+    When the user selects create an account
     Then the user is taken to the "Check your email" page
 
   Scenario: User registration unsuccessful with invalid email, six digit code and password
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
     When the user selects create an account
-    Then the new user is taken to the enter your email page
+    Then the user is taken to the "Enter your email address" page
     When user enters invalid email address
     Then the user is shown an error message
     When user enters "TEST_USER_EMAIL" email address
-    Then the new user is asked to check their email
-    When the new user enters the six digit security code from their email
-    Then the new user is taken to the create your password page
-    And the new user creates and enters an invalid password
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user is taken to the "Create your password" page
+    And the user creates and enters an invalid password
     And there are no accessibility violations
     Then the user is shown an error message
-    And the new user creates and enters a weak password
+    And the user creates and enters a weak password
     Then the user is shown an error message
-    When the new user creates and enters short digit only password
+    When the user creates and enters short digit only password
     Then the user is shown an error message
-    When the new user creates and enters a sequence of numbers password
+    When the user creates and enters a sequence of numbers password
     Then the user is shown an error message
 
   Scenario: User successfully registers using sms
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
     When the user selects create an account
-    Then the new user is taken to the enter your email page
+    Then the user is taken to the "Enter your email address" page
     When user enters "TEST_USER_EMAIL" email address
-    Then the new user is asked to check their email
-    When the new user enters the six digit security code from their email
-    Then the new user is taken to the create your password page
-    When the new user creates a password
-    Then the new user is taken to the get security codes page
-    When the new user chooses "Text message" to get security codes
-    Then the new user is taken to the enter phone number page
-    When the new user enters their mobile phone number using an international dialling code
-    Then the new user is taken to the check your phone page
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user is taken to the "Create your password" page
+    When the user creates a password
+    Then the user is taken to the "Choose how to get security codes" page
+    When the user chooses "Text message" to get security codes
+    Then the user is taken to the "Enter your mobile phone number" page
+    When the user enters their mobile phone number using an international dialling code
+    Then the user is taken to the "Check your phone" page
     When the user clicks the Back link
-    Then the new user is taken to the enter phone number page
-    When the new user enters their mobile phone number
-    Then the new user is taken to the check your phone page
-    When the new user enters the six digit security code from their phone
-    Then the new user is taken to the account created page
-    When the new user clicks the continue button
+    Then the user is taken to the "Enter your mobile phone number" page
+    When the user enters their mobile phone number
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
+    Then the user is taken to the "You’ve created your GOV.UK One Login" page
+    When the user clicks the continue button
     Then the user is returned to the service
     When the user clicks logout
-    Then the new user is taken to the signed out page
+    Then the user is taken to the "Signed out" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/010_existing_user_journey.feature
@@ -5,22 +5,22 @@ Feature: Login Journey
   Scenario: Existing user requests phone OTP code 5 times
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email" page
     When user enters "RESEND_CODE_TEST_USER_EMAIL" email address
     Then the user is taken to the "Enter your password" page
-    When the existing user enters their password
+    When the user enters their password
     Then the user is taken to the "Check your phone" page
-    When the existing user requests the phone otp code 5 times
+    When the user requests the phone otp code 5 times
     Then the user is taken to the "You asked to resend the security code too many times" page
-    When the existing user clicks the get a new code link
+    When the user clicks the get a new code link
     Then the user is taken to the "You cannot get a new security code at the moment" page
 
 
   Scenario: Existing user tries to create an account with the same email address
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects create an account
+    When the user selects create an account
     Then the user is taken to the "Enter your email address" page
     When user enters "TEST_USER_2_EMAIL" email address
     Then the user is taken to the "You have a GOV.UK One Login" page
@@ -29,14 +29,14 @@ Feature: Login Journey
   Scenario: Existing user is correctly prompted to login using sms
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_2_EMAIL" email address
     Then the user is taken to the "Enter your password" page
-    When the existing user enters their password
+    When the user enters their password
     Then the user is taken to the "Check your phone" page
-    When the existing user enters the six digit security code from their phone
-    Then the existing user is returned to the service
+    When the user enters the six digit security code from their phone
+    Then the user is returned to the service
     And the user clicks logout
     Then the user is taken to the "Signed out" page
 
@@ -44,32 +44,32 @@ Feature: Login Journey
   Scenario: Existing user switches content to Welsh
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    And the existing user switches to "Welsh" language
-    Then the existing user is taken to the Identity Provider Welsh Login Page
-    When the existing user selects sign in
-    Then the existing user is taken to the Welsh enter your email page
+    And the user switches to "Welsh" language
+    Then the user is taken to the Identity Provider Welsh Login Page
+    When the user selects sign in
+    Then the user is taken to the Welsh enter your email page
     When user enters "TEST_USER_2_EMAIL" email address in Welsh
-    Then the existing user is prompted for their password in Welsh
+    Then the user is prompted for their password in Welsh
     When the user clicks link "Yn ôl"
-    Then the existing user is taken to the Welsh enter your email page
+    Then the user is taken to the Welsh enter your email page
     When the user clicks link "Yn ôl"
-    Then the existing user is taken to the Identity Provider Welsh Login Page
-    When the existing user switches to "English" language
+    Then the user is taken to the Identity Provider Welsh Login Page
+    When the user switches to "English" language
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
 
 
   Scenario: Existing user logs in without 2FA then uplift with 2FA
     Given the user comes from the stub relying party with options: "2fa-off"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_2_EMAIL" email address
-    Then the existing user is prompted for their password
-    When the existing user enters their password
-    Then the existing user is returned to the service
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
+    Then the user is returned to the service
     When the user comes from the stub relying party with options: "default"
-    Then the existing user is taken to the enter code uplifted page
-    When the existing user enters the six digit security code from their phone
-    Then the existing user is returned to the service
+    Then the user is taken to the "You need to enter a security code" page
+    When the user enters the six digit security code from their phone
+    Then the user is returned to the service
     When the user clicks logout
     Then the user is taken to the "Signed out" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Enforce_100k_password_check.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Enforce_100k_password_check.feature
@@ -5,8 +5,8 @@ Feature: Enforce 100k password check
   Scenario: Existing user forced to reset their top 100k password
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "REQ_RESET_PW_USER_EMAIL" email address
     Then the user is taken to the "Enter your password" page
     When the user enters their password which is on the top 100k password list
@@ -19,7 +19,7 @@ Feature: Enforce 100k password check
     Then the "Enter the same password in both fields" error message is displayed
     When the user enters valid new password and correctly retypes it
     Then the user is taken to the "Check your phone" page
-    When the existing user enters the six digit security code from their phone
+    When the user enters the six digit security code from their phone
     Then the user is taken to the "Example - GOV.UK - User Info" page
     When the user clicks logout
     Then the user is taken to the "Signed out" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/IPN.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/IPN.feature
@@ -6,22 +6,22 @@ Feature: International Phone Numbers
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
     When the user selects create an account
-    Then the new user is taken to the enter your email page
+    Then the user is taken to the "Enter your email" page
     When user enters "IPN1_NEW_USER_EMAIL" email address
-    Then the new user is asked to check their email
-    When the new user enters the six digit security code from their email
-    Then the new user is taken to the create your password page
-    When the new user creates a password
-    Then the new user is taken to the get security codes page
-    When the new user chooses "Text message" to get security codes
-    Then the new user is taken to the enter phone number page
-    When the new user submits a blank UK phone number
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user is taken to the "Create your password" page
+    When the user creates a password
+    Then the user is taken to the "Choose how to get security codes" page
+    When the user chooses "Text message" to get security codes
+    Then the user is taken to the "Enter your mobile phone number" page
+    When the user submits a blank UK phone number
     Then the "Enter a UK mobile phone number" error message is displayed
-    When the new user submits an international phone number in the UK phone number field
+    When the user submits an international phone number in the UK phone number field
     Then the "Enter a UK mobile phone number" error message is displayed
-    When the new user submits an incorrectly formatted UK phone number
+    When the user submits an incorrectly formatted UK phone number
     Then the "Enter a UK mobile phone number, like 07700 900000" error message is displayed
-    When the new user submits a UK phone number containing non-digit characters
+    When the user submits a UK phone number containing non-digit characters
     Then the "Enter a UK mobile phone number using only numbers or the + symbol" error message is displayed
 
 
@@ -30,31 +30,31 @@ Feature: International Phone Numbers
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
     When the user selects create an account
-    Then the new user is taken to the enter your email page
+    Then the user is taken to the "Enter your email" page
     When user enters "IPN2_NEW_USER_EMAIL" email address
-    Then the new user is asked to check their email
-    When the new user enters the six digit security code from their email
-    Then the new user is taken to the create your password page
-    When the new user creates a password
-    Then the new user is taken to the get security codes page
-    When the new user chooses "Text message" to get security codes
-    Then the new user is taken to the enter phone number page
-    When the new user ticks I do not have a UK mobile number
+    Then the user is taken to the "Check your email" page
+    When the user enters the six digit security code from their email
+    Then the user is taken to the "Create your password" page
+    When the user creates a password
+    Then the user is taken to the "Choose how to get security codes" page
+    When the user chooses "Text message" to get security codes
+    Then the user is taken to the "Enter your mobile phone number" page
+    When the user ticks I do not have a UK mobile number
     Then the International mobile number field is displayed
-    When the new user submits a blank international mobile phone number
+    When the user submits a blank international mobile phone number
     Then the "Enter a mobile phone number" error message is displayed
-    When the new user submits an incorrectly formatted international mobile phone number
+    When the user submits an incorrectly formatted international mobile phone number
     Then the "Enter a mobile phone number in the correct format, including the country code" error message is displayed
-    When the new user submits an international mobile phone number containing non-digit characters
+    When the user submits an international mobile phone number containing non-digit characters
     Then the "Enter a mobile phone number using only numbers or the + symbol" error message is displayed
-    When the new user enters a valid international mobile phone number
-    Then the new user is taken to the check your phone page
-    When the new user enters the six digit security code from their phone
-    Then the new user is taken to the account created page
-    When the new user clicks the continue button
+    When the user enters a valid international mobile phone number
+    Then the user is taken to the "Check your phone" page
+    When the user enters the six digit security code from their phone
+    Then the user is taken to the "You’ve created your GOV.UK One Login" page
+    When the user clicks the continue button
     Then the user is returned to the service
     When the user clicks logout
-    Then the new user is taken to the signed out page
+    Then the user is taken to the "Signed out" page
 
 
 #  Scenario: User with an international phone number reports that they did not receive their security code

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reset_password.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/Reset_password.feature
@@ -4,7 +4,7 @@ Feature: Reset password
   Scenario: User can successfully reset their password
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email" page
     When user enters "RESET_PW_USER_EMAIL" email address
     Then the user is taken to the "Enter your password" page
@@ -22,7 +22,7 @@ Feature: Reset password
     Then the "Enter the same password in both fields" error message is displayed
     When the user enters valid new password and correctly retypes it
     Then the user is taken to the "Check your phone" page
-    When the existing user enters the six digit security code from their phone
+    When the user enters the six digit security code from their phone
     Then the user is taken to the "Example - GOV.UK - User Info" page
     When the user clicks logout
     Then the user is taken to the "Signed out" page
@@ -31,7 +31,7 @@ Feature: Reset password
   Scenario: A user is blocked when they request an email OTP more than 5 times during a password reset.
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email" page
     When user enters "TOO_MANY_EMAIL_OTP_REQUESTS_FOR_PW_RESET_EMAIL" email address
     Then the user is taken to the "Enter your password" page
@@ -46,7 +46,7 @@ Feature: Reset password
   Scenario: A user is blocked when they enter an incorrect email OTP more than 5 times during a password reset.
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
+    When the user selects sign in
     Then the user is taken to the "Enter your email" page
     When user enters "INCORRECT_EMAIL_OTP_FOR_PW_RESET_EMAIL" email address
     Then the user is taken to the "Enter your password" page

--- a/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_recovery.feature
+++ b/acceptance-tests/src/test/resources/uk/gov/di/test/features/account_recovery.feature
@@ -4,10 +4,10 @@ Feature: Account recovery
   Scenario: A user with text message authentication changes password and logs in with their MFA. Changes their auth method to auth app, then logs in with the new password and auth app.
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_1" email address
-    Then the existing user is prompted for their password
+    Then the user is taken to the "Enter your password" page
     When the user clicks the forgotten password link
     Then the user is taken to the "Check your email" page
     When the user enters the six digit security code from their email
@@ -16,18 +16,18 @@ Feature: Account recovery
     Then the user is taken to the "Check your phone" page
     When the user selects "Problems with the code?" link
     Then the link "change how you get security codes" is not available
-    When the existing user enters the six digit security code from their phone
+    When the user enters the six digit security code from their phone
     Then the user is taken to the "Example - GOV.UK - User Info" page
     When the user clicks logout
     Then the user is taken to the "Signed out" page
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_1" email address
-    Then the existing user is prompted for their password
-    When the existing user enters their new password
+    Then the user is taken to the "Enter your password" page
+    When the user enters their new password
     Then the user is taken to the "Check your phone" page
     When the user selects "Problems with the code?" link
     And the user selects "change how you get security codes" link
@@ -36,8 +36,8 @@ Feature: Account recovery
     Then the user is taken to the "How do you want to get security codes" page
     When the user selects radio button "Authenticator app for smartphone, tablet or computer"
     Then the user is taken to the "Set up an authenticator app" page
-    When the existing user adds the secret key on the screen to their auth app
-    And the existing user enters the security code from the auth app
+    When the user adds the secret key on the screen to their auth app
+    And the user enters the security code from the auth app
     Then the user is taken to the "You’ve changed how you get security codes" page
     And confirmation that the user will get security codes via "auth app" is displayed
     Then the user is taken to the "Example - GOV.UK - User Info" page
@@ -46,13 +46,13 @@ Feature: Account recovery
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_1" email address
-    Then the existing user is prompted for their password
-    When the existing user enters their new password
+    Then the user is taken to the "Enter your password" page
+    When the user enters their new password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
-    When the existing user enters the security code from the auth app
+    When the user enters the security code from the auth app
     Then the user is taken to the "Example - GOV.UK - User Info" page
     When the user clicks logout
     Then the user is taken to the "Signed out" page
@@ -61,10 +61,10 @@ Feature: Account recovery
   Scenario: A user with auth app authentication changes password and logs in with their MFA. Changes their auth method to text message, then logs in with the new password and text message auth method.
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_2" email address
-    Then the existing user is prompted for their password
+    Then the user is taken to the "Enter your password" page
     When the user clicks the forgotten password link
     Then the user is taken to the "Check your email" page
     When the user enters the six digit security code from their email
@@ -73,18 +73,18 @@ Feature: Account recovery
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     And the link "I do not have access to the authenticator app" is not available
     And the link "change how you get security codes" is not available
-    When the existing user enters the security code from the auth app
+    When the user enters the security code from the auth app
     Then the user is taken to the "Example - GOV.UK - User Info" page
     When the user clicks logout
     Then the user is taken to the "Signed out" page
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_2" email address
-    Then the existing user is prompted for their password
-    When the existing user enters their new password
+    Then the user is taken to the "Enter your password" page
+    When the user enters their new password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user selects link "I do not have access to the authenticator app"
     And the user selects link "change how you get security codes"
@@ -95,7 +95,7 @@ Feature: Account recovery
     Then the user is taken to the "Enter your mobile phone number" page
     When the user enters their mobile phone number
     Then the user is taken to the "Check your phone" page
-    When the existing user enters the six digit security code from their phone
+    When the user enters the six digit security code from their phone
     Then the user is taken to the "You’ve changed how you get security codes" page
     And confirmation that the user will get security codes via "text message" is displayed
     Then the user is taken to the "Example - GOV.UK - User Info" page
@@ -104,13 +104,13 @@ Feature: Account recovery
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_2" email address
-    Then the existing user is prompted for their password
-    When the existing user enters their new password
+    Then the user is taken to the "Enter your password" page
+    When the user enters their new password
     Then the user is taken to the "Check your phone" page
-    When the existing user enters the six digit security code from their phone
+    When the user enters the six digit security code from their phone
     Then the user is taken to the "Example - GOV.UK - User Info" page
     When the user clicks logout
     Then the user is taken to the "Signed out" page
@@ -119,11 +119,11 @@ Feature: Account recovery
   Scenario: A user with sms authentication is blocked when they request their email OTP code 6 times (including the initial send on entry to screen) during a change of auth method.
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_3" email address
-    Then the existing user is prompted for their password
-    When the existing user enters their password
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user selects "Problems with the code?" link
     And the user selects "change how you get security codes" link
@@ -136,11 +136,11 @@ Feature: Account recovery
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_3" email address
-    Then the existing user is prompted for their password
-    When the existing user enters their password
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
     Then the user is taken to the "Check your phone" page
     When the user selects "Problems with the code?" link
     And the user selects "change how you get security codes" link
@@ -150,11 +150,11 @@ Feature: Account recovery
   Scenario: A user with auth app authentication is blocked when they enter an incorrect email OTP 6 times during a change of auth method.
     Given the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_4" email address
-    Then the existing user is prompted for their password
-    When the existing user enters their password
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user selects "I do not have access to the authenticator app" link
     And the user selects "change how you get security codes" link
@@ -166,11 +166,11 @@ Feature: Account recovery
 
     When the user comes from the stub relying party with options: "default"
     Then the user is taken to the "Create a GOV.UK One Login or sign in" page
-    When the existing user selects sign in
-    Then the existing user is taken to the enter your email page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
     When user enters "TEST_USER_ACCOUNT_RECOVERY_EMAIL_4" email address
-    Then the existing user is prompted for their password
-    When the existing user enters their password
+    Then the user is taken to the "Enter your password" page
+    When the user enters their password
     Then the user is taken to the "Enter the 6 digit security code shown in your authenticator app" page
     When the user selects "I do not have access to the authenticator app" link
     And the user selects "change how you get security codes" link


### PR DESCRIPTION
## What?

1. Removed references in steps to 'new' or 'existing' users, and replaced with just 'the user'.
2. Also added some code that adds a cookie so the analytics message doesn't keep appearing.

## Why?

1. To reduce step duplication and will allow us to re-group the step definition files.
2. When the screenshots are taken half the screenshot is the analytics message, and also noticed that in firefox one of the tests would fail because some text it was looking for was off the screen (due to the analytics message)